### PR TITLE
truncation function and cli for lh5 files

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from pkg_resources import get_distribution
+from importlib.metadata import version as im_version
 
 sys.path.insert(0, Path(__file__).parents[2].resolve().as_posix())
 sys.path.append(Path("extensions").resolve().as_posix())
 
 project = "legend-lh5io"
 copyright = "2023, the LEGEND Collaboration"
-version = get_distribution("legend-lh5io").version
+version = im_version("legend-lh5io")
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,9 +2,8 @@
 from __future__ import annotations
 
 import sys
-from pathlib import Path
-
 from importlib.metadata import version as im_version
+from pathlib import Path
 
 sys.path.insert(0, Path(__file__).parents[2].resolve().as_posix())
 sys.path.append(Path("extensions").resolve().as_posix())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ test = [
 [project.scripts]
 lh5ls = "lh5.cli:lh5ls"
 lh5concat = "lh5.cli:lh5concat_cli"
+lh5truncate = "lh5.cli:lh5truncate_cli"
 
 [tool.setuptools]
 include-package-data = true

--- a/src/lh5/cli.py
+++ b/src/lh5/cli.py
@@ -10,6 +10,7 @@ import lgdo.logging as lgdogging  # eheheh
 
 from . import __version__, io
 from .io.concat import lh5concat
+from .io.truncate import truncate
 
 log = logging.getLogger(__name__)
 
@@ -179,6 +180,135 @@ Exclude the /data/table1/col1 Table column:
         lh5_files=args.lh5_file,
         overwrite=args.overwrite,
         output=args.output,
+        include_list=args.include,
+        exclude_list=args.exclude,
+    )
+
+
+def lh5truncate_cli(args=None):
+    """Command line interface for truncating LH5 files."""
+    parser = argparse.ArgumentParser(
+        prog="lh5truncate",
+        description="""
+Truncate LGDO Arrays, VectorOfVectors and Tables in LH5 files.
+
+Examples
+--------
+
+Truncate to keep first 100 rows:
+
+  $ lh5truncate infile.lh5 -o outfile.lh5 100
+
+Truncate with a slice (rows 10 to 50) for hit-ordered data using a TCM file:
+
+  $ lh5truncate infile.lh5 -o outfile.lh5 10:50 --tcm-file tcm.lh5 --file-type raw
+
+Include only specific paths:
+
+  $ lh5truncate infile.lh5 -o outfile.lh5 50 -i 'ch*'
+        """,
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+
+    # global options
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="""Print legend-pydataobj version and exit""",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="""Increase the program verbosity""",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="""Increase the program verbosity to maximum""",
+    )
+
+    parser.add_argument(
+        "lh5_file",
+        help="""Input LH5 file""",
+    )
+    parser.add_argument(
+        "length_or_slice",
+        help="""Number of rows to keep (e.g. 100) or slice notation (e.g. 10:50)""",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        help="""Output file""",
+        required=True,
+    )
+    parser.add_argument(
+        "--overwrite",
+        "-w",
+        action="store_true",
+        help="""Overwrite output file""",
+    )
+    parser.add_argument(
+        "--tcm-file",
+        help="""Path to TCM file (required for hit-ordered truncation)""",
+        default=None,
+    )
+    parser.add_argument(
+        "--file-type",
+        help="""File type (auto-deduced if not provided). Options: evt, tcm, raw,
+        dsp, hit, any-evt, any-hit""",
+        default=None,
+    )
+    parser.add_argument(
+        "--include",
+        "-i",
+        help="""fnmatch pattern for object names to include. The option can be
+        passed multiple times to provide a list of patterns.
+        """,
+        action="append",
+        default=None,
+    )
+    parser.add_argument(
+        "--exclude",
+        "-e",
+        help="""fnmatch pattern for object names to exclude. Takes priority over
+        --include. Can be passed multiple times.
+        """,
+        action="append",
+        default=None,
+    )
+
+    args = parser.parse_args(args)
+
+    if args.verbose:
+        lgdogging.setup(logging.INFO, logging.getLogger("lgdo"))
+    elif args.debug:
+        lgdogging.setup(logging.DEBUG, logging.root)
+    else:
+        lgdogging.setup()
+
+    if args.version:
+        print(__version__)  # noqa: T201
+        sys.exit()
+
+    # parse length_or_slice: could be an integer or a slice like "10:50"
+    length_or_slice: int | slice
+    if ":" in args.length_or_slice:
+        parts = args.length_or_slice.split(":")
+        start = int(parts[0]) if parts[0] else None
+        stop = int(parts[1]) if len(parts) > 1 and parts[1] else None
+        step = int(parts[2]) if len(parts) > 2 and parts[2] else None
+        length_or_slice = slice(start, stop, step)
+    else:
+        length_or_slice = int(args.length_or_slice)
+
+    truncate(
+        infile=args.lh5_file,
+        outfile=args.output,
+        length_or_slice=length_or_slice,
+        overwrite=args.overwrite,
+        tcm_file=args.tcm_file,
+        file_type=args.file_type,
         include_list=args.include,
         exclude_list=args.exclude,
     )

--- a/src/lh5/io/__init__.py
+++ b/src/lh5/io/__init__.py
@@ -28,5 +28,6 @@ __all__ = [
     "read_n_rows",
     "reset_default_hdf5_settings",
     "show",
+    "truncate",
     "write",
 ]

--- a/src/lh5/io/truncate.py
+++ b/src/lh5/io/truncate.py
@@ -8,8 +8,8 @@ import re
 from collections.abc import Callable
 
 import awkward as ak
-
 from lgdo.types import LGDO, Array, Struct, Table, VectorOfVectors, WaveformTable
+
 import lh5
 from lh5 import read, read_as
 

--- a/src/lh5/io/truncate.py
+++ b/src/lh5/io/truncate.py
@@ -280,7 +280,10 @@ def truncate(
     elif file_type in hit_ordered_types:
         hit_ordered = True
     else:
-        msg = f"Unknown file type {file_type}: impossible to deduce if hit- or evt-ordered. Use any-hit or any-evt as file type if the file type is not one of the standard types."
+        msg = (
+            f"Unknown file type {file_type}: impossible to deduce if hit- or evt-ordered. "
+            "Use any-hit or any-evt as file type if the file type is not one of the standard types."
+        )
         raise RuntimeError(msg)
     msg = "hit-ordered data" if hit_ordered else "evt-ordered data"
     log.info(msg)

--- a/src/lh5/io/truncate.py
+++ b/src/lh5/io/truncate.py
@@ -48,17 +48,46 @@ def map_lgdo_arrays(
         return None
     if isinstance(lgdo, WaveformTable):
         # before Table as WaveformTable inherits from Table
-        return WaveformTable(
-            t0=map_lgdo_arrays(func, lgdo.t0, name + "/t0"),  # Array
-            dt=map_lgdo_arrays(func, lgdo.dt, name + "/dt"),  # Array
-            values=map_lgdo_arrays(
-                func, lgdo.values, name + "/values"
-            ),  # AoesA (or VoV?)
-            attrs=lgdo.attrs,
-        )
+        t0 = map_lgdo_arrays(
+            func,
+            lgdo.t0,
+            name + "/t0",
+            include_list=include_list,
+            exclude_list=exclude_list,
+        )  # Array
+        dt = map_lgdo_arrays(
+            func,
+            lgdo.dt,
+            name + "/dt",
+            include_list=include_list,
+            exclude_list=exclude_list,
+        )  # Array
+        values = map_lgdo_arrays(
+            func,
+            lgdo.values,
+            name + "/values",
+            include_list=include_list,
+            exclude_list=exclude_list,
+        )  # AoesA (or VoV?)
+        # WaveformTable is treated as all-or-nothing: if any component is excluded,
+        # drop the entire WaveformTable.
+        if t0 is None or dt is None or values is None:
+            msg = (
+                f"WaveformTable at {name} excluded due to include/exclude rules "
+                f"(t0={t0 is not None}, dt={dt is not None}, values={values is not None})"
+            )
+            log.debug(msg)
+            return None
+        return WaveformTable(t0=t0, dt=dt, values=values, attrs=lgdo.attrs)
     if isinstance(lgdo, (Struct, Table)):
         mp = {
-            key: map_lgdo_arrays(func, val, name + "/" + key)
+            key: map_lgdo_arrays(
+                func,
+                val,
+                name + "/" + key,
+                include_list=include_list,
+                exclude_list=exclude_list,
+            )
             for key, val in lgdo.items()
         }
         mp = {key: val for key, val in mp.items() if val is not None}

--- a/src/lh5/io/truncate.py
+++ b/src/lh5/io/truncate.py
@@ -1,0 +1,304 @@
+"""Truncate lh5 files. Useful for generating test data."""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+import re
+from collections.abc import Callable
+
+import awkward as ak
+
+from lgdo.types import LGDO, Array, Struct, Table, VectorOfVectors, WaveformTable
+import lh5
+from lh5 import read, read_as
+
+log = logging.getLogger(__name__)
+
+
+def _is_included(
+    name: str,
+    *,
+    include_list: list[str] | None = None,
+    exclude_list: list[str] | None = None,
+) -> bool:
+    if exclude_list is not None:
+        for exc in exclude_list:
+            if fnmatch.fnmatch(name, exc.strip("/")):
+                return False
+    if include_list is not None:
+        return any(fnmatch.fnmatch(name, inc.strip("/")) for inc in include_list)
+    return True
+
+
+def map_lgdo_arrays(
+    func: Callable[[str, ak.Array], ak.Array],
+    lgdo: LGDO,
+    name: str,
+    *,
+    include_list: list[str] | None = None,
+    exclude_list: list[str] | None = None,
+) -> LGDO | None:
+    """Map a function acting on awkward arrays contained in the lgdo tree on the tree.
+    The tree structure itself is not altered (compare to map in functional languages).
+    Also, attributes are propagated unchanged."""
+    if not _is_included(name, include_list=include_list, exclude_list=exclude_list):
+        msg = f"{name} does not match pattern incl={include_list}, excl={exclude_list}"
+        log.debug(msg)
+        return None
+    if isinstance(lgdo, WaveformTable):
+        # before Table as WaveformTable inherits from Table
+        return WaveformTable(
+            t0=map_lgdo_arrays(func, lgdo.t0, name + "/t0"),  # Array
+            dt=map_lgdo_arrays(func, lgdo.dt, name + "/dt"),  # Array
+            values=map_lgdo_arrays(
+                func, lgdo.values, name + "/values"
+            ),  # AoesA (or VoV?)
+            attrs=lgdo.attrs,
+        )
+    if isinstance(lgdo, (Struct, Table)):
+        mp = {
+            key: map_lgdo_arrays(func, val, name + "/" + key)
+            for key, val in lgdo.items()
+        }
+        mp = {key: val for key, val in mp.items() if val is not None}
+        return type(lgdo)(mp, attrs=lgdo.attrs)  # inherit attrs from original
+    if isinstance(lgdo, (VectorOfVectors, Array)):  # treat as leave here
+        ak_array = lgdo.view_as("ak")
+        assert isinstance(ak_array, ak.Array)
+        ak_array = func(name, ak_array)  # apply the function here
+        cls = type(lgdo)
+        if isinstance(lgdo, VectorOfVectors):
+            lgdo = cls(
+                data=ak_array, attrs=lgdo.attrs
+            )  # VoV or anything inheriting from it
+        elif isinstance(lgdo, Array):
+            lgdo = cls(nda=ak_array, attrs=lgdo.attrs)  # might be Array or AoesA
+        else:
+            msg = "Array-type lgdo cannot be identified"
+            raise RuntimeError(msg)
+        return lgdo
+    msg = f"Cannot map LGDO at {name}: {type(lgdo)}"  # e.g. Scalar. Might find a way to treat this.
+    raise RuntimeError(msg)
+
+
+def map_lgdo_arrays_on_file(
+    infile: str,
+    outfile: str,
+    func: Callable[[str, ak.Array], ak.Array],
+    overwrite: bool = False,
+    *,
+    include_list: list | None = None,
+    exclude_list: list | None = None,
+) -> None:
+    """Run function func on all vectorofvectors and all arrays in the file.
+    1st arg of func is the name of the lgdo, 2nd is the array within.
+    """
+
+    # list of root lgdo names. Actually 2nd level, since / is the real root.
+    # But I don't want to load all at once for memory reasons.
+    root_lgdo_names = lh5.ls(infile, recursive=False)
+
+    msg = f"objects in {infile}: {root_lgdo_names}"
+    log.info(msg)
+
+    first_done = False
+    store = lh5.LH5Store()
+
+    # loop over lgdo objects
+    for root_name in root_lgdo_names:
+        msg = f"mapping over {root_name}"
+        log.debug(msg)
+        if not _is_included(
+            root_name, include_list=include_list, exclude_list=exclude_list
+        ):
+            # early check to enhance performance
+            msg = f"{root_name} does not match pattern incl={include_list}, excl={exclude_list}"
+            log.debug(msg)
+            continue
+        lh5_obj = read(root_name, infile)
+
+        lh5_obj = map_lgdo_arrays(
+            func,
+            lh5_obj,
+            root_name,
+            include_list=include_list,
+            exclude_list=exclude_list,
+        )
+
+        if lh5_obj is None:
+            msg = f"{root_name} mapped to Null"
+            log.debug(msg)
+            continue
+
+        if first_done is False:
+            msg = f"creating output file {outfile}"
+            log.info(msg)
+
+            store.write(
+                lh5_obj,
+                root_name,
+                outfile,
+                wo_mode="overwrite_file"
+                if (overwrite and not first_done)
+                else "write_safe",
+            )
+            first_done = True
+
+        else:
+            msg = f"appending to {outfile}"
+            log.info(msg)
+
+            # if isinstance(lh5_obj, Table): # should be done already...
+            #    _inplace_table_filter(lgdo, lh5_obj, obj_list)
+
+            store.write(lh5_obj, root_name, outfile, wo_mode="append")
+
+
+def truncate_array_channel(
+    input_array: ak.Array,
+    table_key_trunc: ak.Array,
+    row_in_table_trunc: ak.Array,
+    channel_key: int,
+):
+    row_indices = ak.flatten(row_in_table_trunc[table_key_trunc == channel_key])
+    return input_array[row_indices]
+
+
+# this creates the truncator function for hit-ordered arrays
+def create_hit_ordered_truncation_func(
+    tcm_file: str, length_or_slice: int | slice
+) -> Callable[[str, ak.Array], ak.Array]:
+    row_in_table = read_as("hardware_tcm_1/row_in_table", tcm_file, "ak")
+    table_key = read_as("hardware_tcm_1/table_key", tcm_file, "ak")
+    # truncate
+    slice_ = (
+        length_or_slice
+        if isinstance(length_or_slice, slice)
+        else slice(length_or_slice)
+    )
+    row_in_table_trunc = row_in_table[slice_]
+    table_key_trunc = table_key[slice_]  # was :length
+
+    def truncator(lgdo: str, input_array: ak.Array) -> ak.Array:
+        # Search for the pattern
+        match = re.search(r"^ch(\d+)/", lgdo)
+        if match:
+            channel_key = int(match.group(1))
+            # print(f"Extracted chid: {channel_key}")
+        else:
+            msg = f"Cannot deduce channel key from {lgdo}"
+            raise RuntimeError(msg)
+        return truncate_array_channel(
+            input_array=input_array,
+            table_key_trunc=table_key_trunc,
+            row_in_table_trunc=row_in_table_trunc,
+            channel_key=channel_key,
+        )
+
+    return truncator
+
+
+# this creates the truncator function for evt-ordered arrays (tcm, evt)
+def create_evt_ordered_truncation_func(
+    length_or_slice: int | slice,
+) -> Callable[[str, ak.Array], ak.Array]:
+    slice_ = (
+        length_or_slice
+        if isinstance(length_or_slice, slice)
+        else slice(length_or_slice)
+    )
+
+    def truncator(_: str, input_array: ak.Array) -> ak.Array:
+        return input_array[slice_]
+
+    return truncator
+
+
+def truncate(
+    infile: str,
+    outfile: str,
+    length_or_slice: int | slice,
+    overwrite: bool = False,
+    *,
+    tcm_file: str | None = None,  # required for hit-ordered
+    include_list: list[str] | None = None,
+    exclude_list: list[str] | None = None,
+    file_type: str | None = None,  # auto-deduce from name
+) -> None:
+    """Truncate an LH5 file and write the result to a new file.
+
+    This function produces a truncated copy of `infile` at `outfile` by applying
+    `length_or_slice` to array-like LGDOs contained in the file. There are two
+    supported truncation modes depending on the ordering of the input file:
+
+    - evt-ordered (file types: ``evt``, ``tcm``, ``any-evt``): arrays are truncated
+      by applying `length_or_slice` directly to each array (simple slicing).
+    - hit-ordered (file types: ``raw``, ``dsp``, ``hit``, ``any-hit``): rows belong
+      to channels and the truncation must preserve only those rows that fall into
+      the requested ``length_or_slice`` of the corresponding TCM mapping. For this
+      mode a `tcm_file` must be provided; the function reads
+      ``hardware_tcm_1/row_in_table`` and ``hardware_tcm_1/table_key`` from the
+      TCM file to build the per-channel row selection.
+
+    Parameters
+    ----------
+    infile:
+        Path to the input LH5 file to truncate.
+    outfile:
+        Path to the resulting truncated LH5 file to create.
+    length_or_slice:
+        Integer number of rows to keep (keeps first N rows) or a ``slice``
+        object to select rows. The semantics differ slightly between
+        evt- and hit-ordered files (see above).
+    overwrite:
+        If True, the output file will be overwritten when created; otherwise
+        a safe write/append strategy is used.
+    tcm_file:
+        Path to a TCM LH5 file. Required for hit-ordered truncation to map
+        channel keys to row indices.
+    include_list:
+        Optional list of fnmatch patterns selecting LGDO paths to include.
+    exclude_list:
+        Optional list of fnmatch patterns selecting LGDO paths to exclude.
+    file_type:
+        Optional override of the file type (auto-deduced from `infile` when
+        not provided). Use values like ``evt``, ``tcm``, ``raw``, ``dsp``,
+        ``hit``, or the generic ``any-evt``/``any-hit``.
+    """
+
+    if file_type is None:
+        if (match := re.search(r"tier_([a-z0-9]+)\.lh5", infile)) is not None:
+            file_type = match.group(1)
+        else:
+            msg = f"Cannot deduce file type from filename {infile}"
+            raise RuntimeError(msg)
+    evt_ordered_types = ["evt", "tcm", "any-evt"]
+    hit_ordered_types = ["raw", "dsp", "hit", "any-hit"]
+    if file_type in evt_ordered_types:
+        hit_ordered = False
+    elif file_type in hit_ordered_types:
+        hit_ordered = True
+    else:
+        msg = f"Unknown file type {file_type}: impossible to deduce if hit- or evt-ordered. Use any-hit or any-evt as file type if the file type is not one of the standard types."
+        raise RuntimeError(msg)
+    msg = "hit-ordered data" if hit_ordered else "evt-ordered data"
+    log.info(msg)
+
+    if hit_ordered:
+        if tcm_file is None:
+            msg = "tcm_file is required for hit-ordered files, but is None"
+            raise RuntimeError(msg)
+        truncator = create_hit_ordered_truncation_func(
+            tcm_file=tcm_file, length_or_slice=length_or_slice
+        )
+    else:
+        truncator = create_evt_ordered_truncation_func(length_or_slice=length_or_slice)
+    map_lgdo_arrays_on_file(
+        infile=infile,
+        outfile=outfile,
+        func=truncator,
+        overwrite=overwrite,
+        include_list=include_list,
+        exclude_list=exclude_list,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,5 +26,5 @@ def pytest_sessionfinish(session, exitstatus):  # noqa: ARG001
 @pytest.fixture(scope="session")
 def lgnd_test_data():
     ldata = LegendTestData()
-    ldata.checkout("df10dde")
+    ldata.checkout("59f9763")
     return ldata

--- a/tests/lh5/test_truncate.py
+++ b/tests/lh5/test_truncate.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import awkward as ak
-
 from lgdo import lh5, read_as
+
 from lh5.io import concat
 from lh5.io.truncate import truncate
 

--- a/tests/lh5/test_truncate.py
+++ b/tests/lh5/test_truncate.py
@@ -233,7 +233,7 @@ def test_truncate_dsp(lgnd_test_data, tmptestdir):
         ]
     )
 
-    assert len(read_as("ch1052803/dsp/timestamp", dsp_file, "ak")) <= 25
+    assert len(read_as("ch1052803/dsp/timestamp", outfile1, "ak")) <= 25
 
     # this will fail if outfile1 or outfile2 are too small, probably because there can be
     # channels with 0 entries.

--- a/tests/lh5/test_truncate.py
+++ b/tests/lh5/test_truncate.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import awkward as ak
+
+from lgdo import lh5, read_as
+from lh5.io import concat
+from lh5.io.truncate import truncate
+
+
+def test_truncate_tcm(lgnd_test_data, tmptestdir):
+    # truncate the TCM, which is event-ordered
+    infile = lgnd_test_data.get_path(
+        "lh5/l200-truncated/generated/tier/tcm/ath/p13/r001/l200-p13-r001-ath-20241210T230220Z-tier_tcm.lh5"
+    )
+    # ath -> sparse SiPM data
+    outfile = f"{tmptestdir}/tcm_trunc.lh5"
+
+    # force evt-style truncation (slicing) even on a raw file
+    truncate(infile=infile, outfile=outfile, length_or_slice=5, overwrite=True)
+
+    store = lh5.LH5Store()
+    assert lh5.ls(outfile) == ["hardware_tcm_1"]
+    assert lh5.ls(outfile, "hardware_tcm_1/") == [
+        "hardware_tcm_1/row_in_table",
+        "hardware_tcm_1/table_key",
+    ]
+
+    # read first array-like object and assert its length equals requested truncation
+    obj = store.read("hardware_tcm_1/row_in_table", outfile)
+    assert len(obj) == 5
+    obj = store.read("hardware_tcm_1/table_key", outfile)
+    assert len(obj) == 5
+
+    truncate(
+        infile=infile, outfile=outfile, length_or_slice=slice(2, 6), overwrite=True
+    )
+    obj = store.read("hardware_tcm_1/row_in_table", outfile)
+    assert len(obj) == 4
+    obj = store.read("hardware_tcm_1/table_key", outfile)
+    assert len(obj) == 4
+
+    # no slicing -> stays the same
+    table_key_orig = read_as("hardware_tcm_1/table_key", infile, "ak")
+    truncate(
+        infile=infile,
+        outfile=outfile,
+        length_or_slice=len(table_key_orig),
+        overwrite=True,
+    )
+    assert ak.all(read_as("hardware_tcm_1/table_key", outfile, "ak") == table_key_orig)
+
+
+channellist_sorted = sorted(
+    [
+        "ch1052803",
+        "ch1052804",
+        "ch1054401",
+        "ch1054402",
+        "ch1054403",
+        "ch1054404",
+        "ch1054405",
+        "ch1056000",
+        "ch1056001",
+        "ch1056002",
+        "ch1056003",
+        "ch1056004",
+        "ch1056005",
+        "ch1057600",
+        "ch1057601",
+        "ch1057602",
+        "ch1057603",
+        "ch1057604",
+        "ch1057605",
+        "ch1059200",
+        "ch1059201",
+        "ch1059202",
+        "ch1059204",
+        "ch1060801",
+        "ch1060802",
+        "ch1060803",
+        "ch1060804",
+        "ch1060805",
+        "ch1062400",
+        "ch1062401",
+        "ch1062402",
+        "ch1062403",
+        "ch1062404",
+        "ch1064000",
+        "ch1064001",
+        "ch1064002",
+        "ch1064003",
+        "ch1064004",
+        "ch1065600",
+        "ch1065601",
+        "ch1065602",
+        "ch1065603",
+        "ch1065604",
+        "ch1065605",
+        "ch1067200",
+        "ch1067201",
+        "ch1067202",
+        "ch1067203",
+        "ch1067204",
+    ]
+)
+
+
+def test_truncate_hit(lgnd_test_data, tmptestdir):
+    hit_file = lgnd_test_data.get_path(
+        "lh5/l200-truncated/generated/tier/hit/ath/p13/r001/l200-p13-r001-ath-20241210T230220Z-tier_hit.lh5"
+    )
+    tcm_file = lgnd_test_data.get_path(
+        "lh5/l200-truncated/generated/tier/tcm/ath/p13/r001/l200-p13-r001-ath-20241210T230220Z-tier_tcm.lh5"
+    )
+
+    outfile1 = f"{tmptestdir}/hit_trunc1.lh5"
+    outfile2 = f"{tmptestdir}/hit_trunc2.lh5"
+    outfile_concat = f"{tmptestdir}/hit_trunc_concat.lh5"
+
+    table_key_orig = read_as("hardware_tcm_1/table_key", tcm_file, "ak")
+    total_len = len(table_key_orig)
+    assert total_len > 25
+
+    # two pieces, which we stitch together again later...
+    truncate(
+        infile=hit_file,
+        outfile=outfile1,
+        length_or_slice=25,
+        overwrite=True,
+        tcm_file=tcm_file,
+        include_list=["ch*"],
+    )
+    truncate(
+        infile=hit_file,
+        outfile=outfile2,
+        length_or_slice=slice(25, total_len),
+        overwrite=True,
+        tcm_file=tcm_file,
+        include_list=["ch*"],
+    )
+
+    assert sorted(lh5.ls(outfile1)) == channellist_sorted
+
+    assert sorted(lh5.ls(outfile1, "ch1052803/hit/")) == sorted(
+        [
+            "ch1052803/hit/energy_in_pe",
+            "ch1052803/hit/is_valid_hit",
+            "ch1052803/hit/energy_in_pe_dplms",
+            "ch1052803/hit/is_valid_hit_dplms",
+            "ch1052803/hit/timestamp",
+            "ch1052803/hit/trigger_pos",
+            "ch1052803/hit/trigger_pos_dplms",
+            "ch1052803/hit/has_any_noise",
+        ]
+    )
+
+    # this will fail if outfile1 or outfile2 are too small, probably because there can be
+    # channels with 0 entries.
+    concat.lh5concat(
+        output=outfile_concat, lh5_files=[outfile1, outfile2], overwrite=True
+    )
+
+    assert ak.all(
+        read_as("ch1052803/hit/energy_in_pe", hit_file, "ak")
+        == read_as("ch1052803/hit/energy_in_pe", outfile_concat, "ak")
+    )
+    assert ak.all(
+        read_as("ch1052803/hit/timestamp", hit_file, "ak")
+        == read_as("ch1052803/hit/timestamp", outfile_concat, "ak")
+    )
+    assert ak.all(
+        read_as("ch1052803/hit/has_any_noise", hit_file, "ak")
+        == read_as("ch1052803/hit/has_any_noise", outfile_concat, "ak")
+    )
+    assert ak.all(
+        read_as("ch1057605/hit/energy_in_pe", hit_file, "ak")
+        == read_as("ch1057605/hit/energy_in_pe", outfile_concat, "ak")
+    )
+    assert len(read_as("ch1052803/hit/energy_in_pe", hit_file, "ak")) > len(
+        read_as("ch1052803/hit/energy_in_pe", outfile1, "ak")
+    )
+    assert len(read_as("ch1052803/hit/energy_in_pe", hit_file, "ak")) > len(
+        read_as("ch1052803/hit/energy_in_pe", outfile2, "ak")
+    )
+
+
+def test_truncate_dsp(lgnd_test_data, tmptestdir):
+    dsp_file = lgnd_test_data.get_path(
+        "lh5/l200-truncated/generated/tier/dsp/ath/p13/r001/l200-p13-r001-ath-20241210T230220Z-tier_dsp.lh5"
+    )
+    tcm_file = lgnd_test_data.get_path(
+        "lh5/l200-truncated/generated/tier/tcm/ath/p13/r001/l200-p13-r001-ath-20241210T230220Z-tier_tcm.lh5"
+    )
+
+    outfile1 = f"{tmptestdir}/dsp_trunc1.lh5"
+    outfile2 = f"{tmptestdir}/dsp_trunc2.lh5"
+    outfile_concat = f"{tmptestdir}/dsp_trunc_concat.lh5"
+
+    table_key_orig = read_as("hardware_tcm_1/table_key", tcm_file, "ak")
+    total_len = len(table_key_orig)
+
+    # two pieces, which we stitch together again later...
+    truncate(
+        infile=dsp_file,
+        outfile=outfile1,
+        length_or_slice=25,
+        overwrite=True,
+        tcm_file=tcm_file,
+        include_list=["ch*"],
+    )
+    truncate(
+        infile=dsp_file,
+        outfile=outfile2,
+        length_or_slice=slice(25, total_len),
+        overwrite=True,
+        tcm_file=tcm_file,
+        include_list=["ch*"],
+    )
+
+    assert sorted(lh5.ls(outfile1)) == channellist_sorted
+
+    assert sorted(lh5.ls(outfile1, "ch1052803/dsp/")) == sorted(
+        [
+            "ch1052803/dsp/curr_fwhm",
+            "ch1052803/dsp/energy",
+            "ch1052803/dsp/energy_dplms",
+            "ch1052803/dsp/timestamp",
+            "ch1052803/dsp/trigger_pos",
+            "ch1052803/dsp/trigger_pos_dplms",
+            "ch1052803/dsp/wf_lower_hwhm",
+            "ch1052803/dsp/wf_min",
+            "ch1052803/dsp/wf_mode",
+        ]
+    )
+
+    assert len(read_as("ch1052803/dsp/timestamp", dsp_file, "ak")) <= 25
+
+    # this will fail if outfile1 or outfile2 are too small, probably because there can be
+    # channels with 0 entries.
+    concat.lh5concat(
+        output=outfile_concat, lh5_files=[outfile1, outfile2], overwrite=True
+    )
+
+    assert ak.all(
+        read_as("ch1052803/dsp/energy", dsp_file, "ak")
+        == read_as("ch1052803/dsp/energy", outfile_concat, "ak")
+    )
+    assert ak.all(
+        read_as("ch1052803/dsp/timestamp", dsp_file, "ak")
+        == read_as("ch1052803/dsp/timestamp", outfile_concat, "ak")
+    )
+    assert ak.all(
+        read_as("ch1052803/dsp/trigger_pos", dsp_file, "ak")
+        == read_as("ch1052803/dsp/trigger_pos", outfile_concat, "ak")
+    )
+    assert ak.all(
+        read_as("ch1052803/dsp/wf_min", dsp_file, "ak")
+        == read_as("ch1052803/dsp/wf_min", outfile_concat, "ak")
+    )
+    assert ak.all(
+        read_as("ch1057605/dsp/energy", dsp_file, "ak")
+        == read_as("ch1057605/dsp/energy", outfile_concat, "ak")
+    )
+
+
+def test_truncate_raw(lgnd_test_data, tmptestdir):
+    raw_file = lgnd_test_data.get_path(
+        "lh5/l200-truncated/generated/tier/raw/ath/p13/r001/l200-p13-r001-ath-20241210T230220Z-tier_raw.lh5"
+    )
+    tcm_file = lgnd_test_data.get_path(
+        "lh5/l200-truncated/generated/tier/tcm/ath/p13/r001/l200-p13-r001-ath-20241210T230220Z-tier_tcm.lh5"
+    )
+
+    outfile1 = f"{tmptestdir}/raw_trunc1.lh5"
+    outfile2 = f"{tmptestdir}/raw_trunc2.lh5"
+    outfile_concat = f"{tmptestdir}/raw_trunc_concat.lh5"
+
+    table_key_orig = read_as("hardware_tcm_1/table_key", tcm_file, "ak")
+    total_len = len(table_key_orig)
+
+    # two pieces, which we stitch together again later...
+    truncate(
+        infile=raw_file,
+        outfile=outfile1,
+        length_or_slice=25,
+        overwrite=True,
+        tcm_file=tcm_file,
+        include_list=["ch*"],
+    )
+    truncate(
+        infile=raw_file,
+        outfile=outfile2,
+        length_or_slice=slice(25, total_len),
+        overwrite=True,
+        tcm_file=tcm_file,
+        include_list=["ch*"],
+    )
+
+    assert sorted(lh5.ls(outfile1)) == channellist_sorted
+
+    assert sorted(lh5.ls(outfile1, "ch1052803/raw/")) == sorted(
+        [
+            "ch1052803/raw/abs_delta_mu_usec",
+            "ch1052803/raw/baseline",
+            "ch1052803/raw/board_id",
+            "ch1052803/raw/channel",
+            "ch1052803/raw/daqenergy",
+            "ch1052803/raw/deadinterval_nsec",
+            "ch1052803/raw/deadtime",
+            "ch1052803/raw/delta_mu_usec",
+            "ch1052803/raw/dr_ch_idx",
+            "ch1052803/raw/dr_ch_len",
+            "ch1052803/raw/dr_maxticks",
+            "ch1052803/raw/dr_start_pps",
+            "ch1052803/raw/dr_start_ticks",
+            "ch1052803/raw/dr_stop_pps",
+            "ch1052803/raw/dr_stop_ticks",
+            "ch1052803/raw/event_type",
+            "ch1052803/raw/eventnumber",
+            "ch1052803/raw/fc_input",
+            "ch1052803/raw/fcid",
+            "ch1052803/raw/lifetime",
+            "ch1052803/raw/mu_offset_sec",
+            "ch1052803/raw/mu_offset_usec",
+            "ch1052803/raw/numtraces",
+            "ch1052803/raw/packet_id",
+            "ch1052803/raw/runtime",
+            "ch1052803/raw/timestamp",
+            "ch1052803/raw/to_master_sec",
+            "ch1052803/raw/to_start_sec",
+            "ch1052803/raw/to_start_usec",
+            "ch1052803/raw/ts_maxticks",
+            "ch1052803/raw/ts_pps",
+            "ch1052803/raw/ts_ticks",
+            "ch1052803/raw/waveform_bit_drop",
+        ]
+    )
+
+    # this will fail if outfile1 or outfile2 are too small, probably because there can be
+    # channels with 0 entries.
+    concat.lh5concat(
+        output=outfile_concat, lh5_files=[outfile1, outfile2], overwrite=True
+    )
+
+    assert ak.all(
+        read_as("ch1052803/raw/baseline", raw_file, "ak")
+        == read_as("ch1052803/raw/baseline", outfile_concat, "ak")
+    )
+    assert ak.all(
+        read_as("ch1052803/raw/timestamp", raw_file, "ak")
+        == read_as("ch1052803/raw/timestamp", outfile_concat, "ak")
+    )
+    assert ak.all(
+        read_as("ch1052803/raw/waveform_bit_drop/t0", raw_file, "ak")
+        == read_as("ch1052803/raw/waveform_bit_drop/t0", outfile_concat, "ak")
+    )
+    assert ak.all(
+        read_as("ch1052803/raw/waveform_bit_drop/values", raw_file, "ak")
+        == read_as("ch1052803/raw/waveform_bit_drop/values", outfile_concat, "ak")
+    )
+    assert ak.all(
+        read_as("ch1057605/raw/waveform_bit_drop/values", raw_file, "ak")
+        == read_as("ch1057605/raw/waveform_bit_drop/values", outfile_concat, "ak")
+    )


### PR DESCRIPTION
 - truncates lgdos in lh5 files event-based, using info from the tcm
 - Selection for including/excluding tables
- Hit-ordered files (raw, dsp, hit): currently only top-level Structs in the form of chXXXX are supported, since they provide the necessary mapping to raw ids.

