### PR TITLE
Updates to LH5Iterator

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,7 @@ sys.path.append(Path("extensions").resolve().as_posix())
 
 project = "legend-lh5io"
 copyright = "2023, the LEGEND Collaboration"
-version = metadata.version("legend-pydataobj")
+version = metadata.version(project)
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,16 +2,15 @@
 from __future__ import annotations
 
 import sys
+from importlib import metadata
 from pathlib import Path
-
-from pkg_resources import get_distribution
 
 sys.path.insert(0, Path(__file__).parents[2].resolve().as_posix())
 sys.path.append(Path("extensions").resolve().as_posix())
 
 project = "legend-lh5io"
 copyright = "2023, the LEGEND Collaboration"
-version = get_distribution("legend-lh5io").version
+version = metadata.version("legend-pydataobj")
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/docs/source/notebooks/DataCompression.ipynb
+++ b/docs/source/notebooks/DataCompression.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Data compression\n",
     "\n",
-    "*legend-pydataobj* gives the user a lot of flexibility in choosing how to compress LGDOs, on disk or in memory, through traditional HDF5 filters or custom waveform compression algorithms."
+    "*lh5.compression* gives the user a lot of flexibility in choosing how to compress LGDOs, on disk or in memory, through traditional HDF5 filters or custom waveform compression algorithms."
    ]
   },
   {
@@ -21,7 +21,8 @@
     "\n",
     "import lgdo\n",
     "import numpy as np\n",
-    "from lgdo import lh5"
+    "\n",
+    "import lh5"
    ]
   },
   {
@@ -102,7 +103,7 @@
    "id": "8",
    "metadata": {},
    "source": [
-    "Looks like the data is compressed with [Gzip](http://www.gzip.org) (compression level 4) by default! This default setting is stored in the global `lh5.settings.DEFAULT_HDF5_SETTINGS` variable:"
+    "Looks like the data is compressed with [Gzip](http://www.gzip.org) (compression level 4) by default! This default setting is stored in the global `lh5.io.settings.DEFAULT_HDF5_SETTINGS` variable:"
    ]
   },
   {
@@ -112,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lh5.settings.DEFAULT_HDF5_SETTINGS"
+    "lh5.io.settings.DEFAULT_HDF5_SETTINGS"
    ]
   },
   {
@@ -123,7 +124,7 @@
     "Which specifies the default keyword arguments forwarded to [h5py.Group.create_dataset()](https://docs.h5py.org/en/stable/high/group.html#h5py.Group.create_dataset) and can be overridden by the user.\n",
     "\n",
     "<div class=\"alert alert-info\">\n",
-    "**Important:** do not import `DEFAULT_HDF5_SETTINGS` in your namespace, import `lh5.settings` and modify `lh5.settings.DEFAULT_HDF5_SETTINGS`. Otherwise, changes won't have any effect.\n",
+    "**Important:** do not import `DEFAULT_HDF5_SETTINGS` in your namespace, import `lh5.io.settings` and modify `lh5.io.settings.DEFAULT_HDF5_SETTINGS`. Otherwise, changes won't have any effect.\n",
     "</div>\n",
     "\n",
     "Examples:"
@@ -137,18 +138,18 @@
    "outputs": [],
    "source": [
     "# use another built-in filter\n",
-    "lh5.settings.DEFAULT_HDF5_SETTINGS = {\"compression\": \"lzf\"}\n",
+    "lh5.io.settings.DEFAULT_HDF5_SETTINGS = {\"compression\": \"lzf\"}\n",
     "\n",
     "# specify filter name and options\n",
-    "lh5.settings.DEFAULT_HDF5_SETTINGS = {\"compression\": \"gzip\", \"compression_opts\": 7}\n",
+    "lh5.io.settings.DEFAULT_HDF5_SETTINGS = {\"compression\": \"gzip\", \"compression_opts\": 7}\n",
     "\n",
     "# specify a registered filter provided by hdf5plugin\n",
     "import hdf5plugin\n",
     "\n",
-    "lh5.settings.DEFAULT_HDF5_SETTINGS = {\"compression\": hdf5plugin.Blosc()}\n",
+    "lh5.io.settings.DEFAULT_HDF5_SETTINGS = {\"compression\": hdf5plugin.Blosc()}\n",
     "\n",
     "# shuffle bytes before compressing (typically better compression ratio with no performance penalty)\n",
-    "lh5.settings.DEFAULT_HDF5_SETTINGS = {\"shuffle\": True, \"compression\": \"lzf\"}"
+    "lh5.io.settings.DEFAULT_HDF5_SETTINGS = {\"shuffle\": True, \"compression\": \"lzf\"}"
    ]
   },
   {
@@ -193,7 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lh5.settings.DEFAULT_HDF5_SETTINGS = lh5.settings.default_hdf5_settings()"
+    "lh5.io.settings.DEFAULT_HDF5_SETTINGS = lh5.io.settings.default_hdf5_settings()"
    ]
   },
   {
@@ -266,7 +267,7 @@
    "source": [
     "## Waveform compression\n",
     "\n",
-    "*legend-pydataobj* implements fast custom waveform compression routines in the [lgdo.compression](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.compression.html) subpackage.\n",
+    "*lh5.compression* implements fast custom waveform compression routines in the [lh5.compression](https://legend-lh5io.readthedocs.io/en/latest/api/lh5.compression.html#module-lh5.compression) subpackage.\n",
     "\n",
     "Let's try them out on some waveform test data:"
    ]
@@ -293,10 +294,10 @@
    "id": "24",
    "metadata": {},
    "source": [
-    "Let's encode the waveform values with the [RadwareSigcompress](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.compression.html#lgdo.compression.radware.RadwareSigcompress) codec.\n",
+    "Let's encode the waveform values with the [RadwareSigcompress](https://legend-lh5io.readthedocs.io/en/latest/api/lh5.compression.html#lh5.compression.radware.RadwareSigcompress) codec.\n",
     "\n",
     "<div class=\"alert alert-info\">\n",
-    "**Note:** samples from these test waveforms must be shifted by -32768 for compatibility reasons, see [lgdo.compression.radware.encode()](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.compression.html#lgdo.compression.radware.encode).\n",
+    "**Note:** samples from these test waveforms must be shifted by -32768 for compatibility reasons, see [lgdo.compression.radware.encode()](https://legend-lh5io.readthedocs.io/en/latest/api/lh5.compression.html#lh5.compression.radware.encode).\n",
     "</div>"
    ]
   },
@@ -307,7 +308,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lgdo.compression import RadwareSigcompress, encode\n",
+    "from lh5.compression import RadwareSigcompress, encode\n",
     "\n",
     "enc_values = encode(wfs.values, RadwareSigcompress(codec_shift=-32768))\n",
     "enc_values"
@@ -434,7 +435,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lgdo.compression import decode\n",
+    "from lh5.compression import decode\n",
     "\n",
     "decode(obj.values)"
    ]
@@ -454,7 +455,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lgdo.compression import ULEB128ZigZagDiff\n",
+    "from lh5.compression import ULEB128ZigZagDiff\n",
     "\n",
     "wfs.values.attrs[\"compression\"] = ULEB128ZigZagDiff()\n",
     "lh5.write(wfs, \"waveforms\", \"data.lh5\", wo_mode=\"of\")\n",
@@ -470,9 +471,9 @@
    "source": [
     "Further reading:\n",
     "\n",
-    "- [Available waveform compression algorithms](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.compression.html)\n",
-    "- [read() docstring](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.html#lgdo.lh5.store.LH5Store.read)\n",
-    "- [write() docstring](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.html#lgdo.lh5_store.LH5Store.write)"
+    "- [Available waveform compression algorithms](https://legend-lh5io.readthedocs.io/en/latest/api/lh5.compression.html#module-lh5.compression)\n",
+    "- [read() docstring](https://legend-lh5io.readthedocs.io/en/latest/api/lh5.io.html#lh5.io.core.read)\n",
+    "- [write() docstring](https://legend-lh5io.readthedocs.io/en/latest/api/lh5.io.html#lh5.io.core.write)"
    ]
   }
  ],

--- a/docs/source/notebooks/LH5Files.ipynb
+++ b/docs/source/notebooks/LH5Files.ipynb
@@ -40,7 +40,7 @@
    "id": "3",
    "metadata": {},
    "source": [
-    "We can use `lgdo.lh5.ls()` [[docs]](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.html#lgdo.lh5.tools.ls) to inspect the file contents:"
+    "We can use `lh5.ls()` [[docs]](https://legend-lh5io.readthedocs.io/en/latest/api/lh5.io.html#lh5.io.tools.ls) to inspect the file contents:"
    ]
   },
   {
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lgdo import lh5\n",
+    "import lh5\n",
     "\n",
     "lh5.ls(lh5_file)"
    ]
@@ -81,7 +81,7 @@
    "source": [
     "<div class=\"alert alert-info\">\n",
     "\n",
-    "**Note:** Alternatively to `ls()`, `show()` [[docs]](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.html#lgdo.lh5.tools.show) prints a nice representation of the LH5 file contents (with LGDO types) on screen:\n",
+    "**Note:** Alternatively to `ls()`, `show()` [[docs]](https://legend-lh5io.readthedocs.io/en/latest/api/lh5.io.html#lh5.io.tools.show) prints a nice representation of the LH5 file contents (with LGDO types) on screen:\n",
     "\n",
     "</div>"
    ]
@@ -101,7 +101,7 @@
    "id": "9",
    "metadata": {},
    "source": [
-    "The group contains several LGDOs. Let's read them in memory. `read()` [[docs]](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.lh5.html#lgdo.lh5.core.read) reads an LGDO from disk and returns the object in memory. Let's try to read `geds/raw`:"
+    "The group contains several LGDOs. Let's read them in memory. `read()` [[docs]](https://legend-lh5io.readthedocs.io/en/latest/api/lh5.io.html#lh5.io.core.read) reads an LGDO from disk and returns the object in memory. Let's try to read `geds/raw`:"
    ]
   },
   {
@@ -179,7 +179,7 @@
    "id": "17",
    "metadata": {},
    "source": [
-    "As you might have noticed, `read()` loads all the requested data in memory at once. This can be a problem when dealing with large datasets. `LH5Iterator` [[docs]](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.html#lgdo.lh5.iterator.LH5Iterator) makes it possible to handle data one chunk at a time (sequentially) to avoid running out of memory:"
+    "As you might have noticed, `read()` loads all the requested data in memory at once. This can be a problem when dealing with large datasets. `LH5Iterator` [[docs]](https://legend-lh5io.readthedocs.io/en/latest/api/lh5.io.html#lh5.io.iterator.LH5Iterator) makes it possible to handle data one chunk at a time (sequentially) to avoid running out of memory:"
    ]
   },
   {
@@ -189,7 +189,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lgdo.lh5 import LH5Iterator\n",
+    "from lh5 import LH5Iterator\n",
     "\n",
     "for lh5_obj in LH5Iterator(lh5_file, \"geds/raw/energy\", buffer_len=20):\n",
     "    print(f\"energy = {lh5_obj} ({len(lh5_obj)} rows)\")"
@@ -200,7 +200,7 @@
    "id": "19",
    "metadata": {},
    "source": [
-    "If working with many files at the same time, the`LH5Store` [[docs]](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.html#lgdo.lh5.store.LH5Store) class might come handy:"
+    "If working with many files at the same time, the`LH5Store` [[docs]](https://legend-lh5io.readthedocs.io/en/latest/api/lh5.io.html#lh5.io.store.LH5Store) class might come handy:"
    ]
   },
   {
@@ -210,7 +210,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lgdo.lh5 import LH5Store\n",
+    "from lh5 import LH5Store\n",
     "\n",
     "store = LH5Store(\n",
     "    keep_open=True\n",
@@ -269,7 +269,7 @@
    "id": "26",
    "metadata": {},
    "source": [
-    "### Converting LGDO data to alternative formats\n",
+    "### Reading LH5 data to alternative formats\n",
     "\n",
     "Each LGDO is equipped with a class method called `view_as()` [[docs]](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.types.html#lgdo.types.lgdo.LGDO.view_as), which allows the user to \"view\" the data (i.e. avoiding copying data as much as possible) in a different, third-party format.\n",
     "\n",
@@ -398,7 +398,7 @@
    "id": "38",
    "metadata": {},
    "source": [
-    "Note that we also provide the `read_as()` [[docs]](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.lh5.html#lgdo.lh5.core.read_as) shortcut to save some typing, for users that would like to read LH5 data on disk straight into some third-party format:"
+    "Note that we also provide the `read_as()` [[docs]](https://legend-lh5io.readthedocs.io/en/latest/api/lh5.io.html#lh5.io.core.read_as) shortcut to save some typing, for users that would like to read LH5 data on disk straight into some third-party format:"
    ]
   },
   {
@@ -475,7 +475,7 @@
    "id": "45",
    "metadata": {},
    "source": [
-    "The `write()` [[docs]](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.lh5.html#lgdo.lh5.core.write) function makes it possible to write LGDO objects on disk. Let's start by writing `scalar` with name `message` in a file named `my_data.lh5` in the current directory:"
+    "The `write()` [[docs]](https://legend-lh5io.readthedocs.io/en/latest/api/lh5.io.html#lh5.io.core.write) function makes it possible to write LGDO objects on disk. Let's start by writing `scalar` with name `message` in a file named `my_data.lh5` in the current directory:"
    ]
   },
   {

--- a/docs/source/notebooks/LH5Iterator.ipynb
+++ b/docs/source/notebooks/LH5Iterator.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Reading LH5 Data at Scale\n",
     "\n",
-    "Reading very large quantities of data can incur performance penalties if not done carefully, due to large memory usage and/or a large number of files to be read. To assist in reading large quantities of data in a scalable way, use the [LH5Iterator](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.lh5.html#module-lgdo.lh5.iterator). This will break your data into smaller chunks so that you can process each chunk individually; in addition, special tools exist for parallelizing your processing across the chunks (parallel processing must be independent across threads!)"
+    "Reading very large quantities of data can incur performance penalties if not done carefully, due to large memory usage and/or a large number of files to be read. To assist in reading large quantities of data in a scalable way, use the [LH5Iterator](https://legend-lh5io.readthedocs.io/en/latest/api/lh5.io.html#lh5.io.iterator.LH5Iterator). This will break your data into smaller chunks so that you can process each chunk individually; in addition, special tools exist for parallelizing your processing across the chunks (parallel processing must be independent across threads!)"
    ]
   },
   {
@@ -32,7 +32,8 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "from legendtestdata import LegendTestData\n",
-    "from lgdo.lh5 import LH5Iterator\n",
+    "\n",
+    "from lh5 import LH5Iterator\n",
     "\n",
     "ldata = LegendTestData()\n",
     "\n",
@@ -192,7 +193,7 @@
     "In the above examples, we have used the iterator to loop through many datasets, and select entries to put into a smaller dataset. Because this is one of the most common use-cases for `LH5Iterator`, specialized functions for speeding this process up exist.\n",
     "\n",
     "#### query\n",
-    "The [query](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.lh5.html#lgdo.lh5.iterator.LH5Iterator.query) function can be used to grab a subset of data based on some selection. The section uses [Table.eval](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.types.html#lgdo.types.table.Table.eval) to evaluate the selection, and can access commands from `numexpr` and `awkward` packages."
+    "The [query](https://legend-lh5io.readthedocs.io/en/latest/api/lh5.io.html#lh5.io.iterator.LH5Iterator.query) function can be used to grab a subset of data based on some selection. The selection uses `eval` to interpret the code, and can use the `awkward` and `numpy` packages to evaluate the selection."
    ]
   },
   {
@@ -236,7 +237,7 @@
    "id": "15",
    "metadata": {},
    "source": [
-    "In addition, it is possible to query data and fill a [Hist](https://hist.readthedocs.io/en/latest/) by using the [hist](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.lh5.html#lgdo.lh5.iterator.LH5Iterator.hist) command:"
+    "In addition, it is possible to query data and fill a [Hist](https://hist.readthedocs.io/en/latest/) by using the [hist](https://legend-lh5io.readthedocs.io/en/latest/api/lh5.io.html#lh5.io.iterator.LH5Iterator.hist) command:"
    ]
   },
   {
@@ -299,7 +300,7 @@
    "metadata": {},
    "source": [
     "### Parallel processing\n",
-    "To boost the speed of accessing a large amount of data via the iterator, you can access and process datasets in parallel by calling [map](https://legend-pydataobj.readthedocs.io/en/stable/api/lgdo.lh5.html#lgdo.lh5.iterator.LH5Iterator.map). `map` works by splitting the datasets in each file and group among different threads, and iterating over them in parallel. This is built on the python standard library's [concurrent.futures](https://docs.python.org/3/library/concurrent.futures.html) `Executor` framework; the default is to use multi-processing. Both query and hist are capable of running in parallel by taking advantage of this function; `map` is intended to give advanced users more flexibility.\n",
+    "To boost the speed of accessing a large amount of data via the iterator, you can access and process datasets in parallel by calling [map](https://legend-lh5io.readthedocs.io/en/latest/api/lh5.io.html#lh5.io.iterator.LH5Iterator.map). `map` works by splitting the datasets in each file and group among different threads, and iterating over them in parallel. This is built on the python standard library's [concurrent.futures](https://docs.python.org/3/library/concurrent.futures.html) `Executor` framework; the default is to use multi-processing. Both query and hist are capable of running in parallel by taking advantage of this function; `map` is intended to give advanced users more flexibility.\n",
     "\n",
     "Map will call a single function on each sub-table read while iterating through datasets. The output of the function will by default be collected into a python list; however, you can also provide an aggregator function that will combine the outputs from different tables in a customizable way (see the `aggregate` and `init` arguments). In addition, it is possible to define a function call to run before beginning and upon termination of the loop, which can be used to initialize more complex processes (see the `begin` and `terminate` arguments).\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "numpy>=1.21",
     "pandas>=1.4.4",
     "parse",
-    "legend-pydataobj>=1.16.0",
+    "legend-pydataobj>=2.0.0a2",
 ]
 dynamic = [
     "version",

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -1110,9 +1110,9 @@ class LH5Iterator(Iterator):
               - ``pandas.DataFrame``: pandas dataframe. Treat as mapping from column
                 name to values
 
-            - A string expression. This will call `eval`, with the table columns
+            - A string expression. This will call ``eval``, with the table columns
               provided as local variables formatted as :meth:`awkward.Array`, and
-              access to :module:`awkward` (or `ak`) and :module:`numpy` (or `np`).
+              access to :mod:`awkward` (or ``ak``) and :mod:`numpy` (or ``np``).
               Return a table formatted according to ``library``
 
         fields:
@@ -1220,9 +1220,9 @@ class LH5Iterator(Iterator):
               - ``Mapping[str, ArrayLike]``: mapping from axis name to values
               - :class:`pandas.DataFrame`: treat as mapping from column name to values
 
-            - A string expression. This will call `eval`, with the table columns
+            - A string expression. This will call ``eval``, with the table columns
               provided as local variables formatted as :meth:`awkward.Array`, and
-              access to :module:`awkward` (or `ak`) and :module:`numpy` (or `np`)
+              access to :mod:`awkward` (or ``ak``) and :mod:`numpy` (or ``np``).
 
         keys:
             list of keys fields corresponding to axes. Use if where

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -723,9 +723,12 @@ class LH5Iterator(Iterator):
             # deepcopy required to prevent ownership conflict
             tb_gd = deepcopy(Table(self.group_data[0:1], 1))
             tb_gd.resize(len(self.lh5_buffer))
-            for f in tb_gd:
-                if f in remaining_fields:
-                    remaining_fields.pop(f)
+            if isinstance(remaining_fields, dict):
+                for f in tb_gd:
+                    if f in remaining_fields:
+                        del remaining_fields[f]
+            else:
+                remaining_fields -= set(tb_gd)
             self.lh5_buffer.join(tb_gd)
 
         if warn_missing and len(remaining_fields) > 0:

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -13,10 +13,10 @@ import awkward as ak
 import numpy as np
 import pandas as pd
 from hist import Hist, axis
-from lgdo.types import LGDOCollection, Table
-from lgdo.units import default_units_registry as ureg
 from numpy.typing import NDArray
 
+from lgdo.types import LGDOCollection, Table
+from lgdo.units import default_units_registry as ureg
 from .store import LH5Store
 from .utils import expand_path
 
@@ -32,7 +32,7 @@ class LH5Iterator(Iterator):
     --------
     Iterate through a table one chunk at a time and call ``process`` on each chunk::
 
-            from lgdo.lh5 import LH5Iterator
+            from lh5 import LH5Iterator
             for table in LH5Iterator("data.lh5", "geds/raw/energy", buffer_len=100):
                 process(table)
 
@@ -78,6 +78,7 @@ class LH5Iterator(Iterator):
         friend: Collection[LH5Iterator] = None,
         friend_prefix: str = "",
         friend_suffix: str = "",
+        safe_mode: bool = True,
         h5py_open_mode: str = "r",
     ) -> None:
         """
@@ -153,6 +154,9 @@ class LH5Iterator(Iterator):
             prefix for fields in friend iterator for resolving naming conflicts
         friend_suffix
             suffix for fields in friend iterator for resolving naming conflicts
+        safe_mode
+            if ``True`` and a friend iterator has a different number of files,
+            groups, or elements in a dataset, raise an Exception.
         h5py_open_mode
             file open mode used when acquiring file handles. ``r`` (default)
             opens files read-only while ``a`` allow opening files for
@@ -223,30 +227,56 @@ class LH5Iterator(Iterator):
         if isinstance(group_data, pd.DataFrame):
             self.group_data = ak.Array(dict(group_data))
         elif group_data is not None:
-            self.group_data = ak.Array(group_data)
+            self.group_data = ak.from_iter(group_data)
         else:
             self.group_data = None
 
-        if isinstance(self.group_data, ak.Array):
+        # check that groups and lh5_files are compatible
+        if len(self.groups) != len(self.lh5_files):
+            msg = "lh5_files and groups could not be broadcast onto one another"
+            raise ValueError(msg)
+
+        if isinstance(self.group_data, (ak.Array, ak.Record)):
             if not self.group_data.fields:
                 msg = "group_data must have named fields"
                 raise ValueError(msg)
-            self.group_data = ak.zip(
-                {f: self.group_data[f] for f in self.group_data.fields}
-            )
-            if self.group_data.ndim == 1:
-                self.group_data = ak.Array([self.group_data] * len(self.lh5_files))
-            if not all(
-                len(gd) == len(gps)
-                for gd, gps in zip(self.group_data, self.groups, strict=False)
-            ):
-                msg = "group_data must have same array structure as groups"
-                raise ValueError(msg)
 
-        # check that groups and lh5_files are compatible
-        if len(self.groups) != len(self.lh5_files):
-            msg = "lh5_files and groups must have same length at first level of nesting"
-            raise ValueError(msg)
+            # flatten out any nested fields with _'s
+            def flatten_fields(ar: ak.Array):
+                ret = {}
+                for f in ar.fields:
+                    if not isinstance(ar[f], ak.Record):
+                        ret[f] = ar[f]
+                    else:
+                        contents = flatten_fields(ar[f])
+                        for sub_f, val in contents.items():
+                            ret[f"{f}_{sub_f}"] = val
+                return ret
+
+            self.group_data = flatten_fields(self.group_data)
+
+            # repeat group data over any dimensions as needed
+            broadcast_files = not all(
+                not isinstance(ar, ak.Array) or len(ar) == len(self.lh5_files)
+                for ar in self.group_data.values()
+            )
+            records = []
+            for i_f, gps in enumerate(self.groups):
+                records.append([])
+
+                for ar in self.group_data.values():
+                    v = ar if broadcast_files else ar[i_f]
+                    if isinstance(v, ak.Array) and len(v) != len(gps):
+                        msg = "group_data could not be broadcast onto groups"
+                        raise ValueError(msg)
+
+                for i_g in range(len(gps)):
+                    record = {}
+                    for f, ar in self.group_data.items():
+                        v = ar if broadcast_files else ar[i_f]
+                        record[f] = v if not isinstance(v, ak.Array) else v[i_g]
+                    records[i_f].append(record)
+            self.group_data = ak.Array(records)
 
         # outer-product and flatten nested lists to get all group/file combinations for datasets
         file_list = []
@@ -263,7 +293,8 @@ class LH5Iterator(Iterator):
                     group_data_list.append(gd_list[i_g])
         self.lh5_files = file_list
         self.groups = group_list
-        self.group_data = group_data_list
+        if self.group_data is not None:
+            self.group_data = ak.fill_none(ak.Array(group_data_list), np.nan)
         self.n_datasets = len(self.lh5_files)
 
         if entry_list is not None and entry_mask is not None:
@@ -313,6 +344,7 @@ class LH5Iterator(Iterator):
         self.buffer_len = buffer_len
 
         # Attach the friend(s)
+        self.safe_mode = safe_mode
         if friend is None:
             friend = []
         elif isinstance(friend, LH5Iterator):
@@ -368,6 +400,8 @@ class LH5Iterator(Iterator):
         """Helper to get cumulative dataset length of file/groups"""
         if i_ds < 0:
             return 0
+        elif i_ds >= len(self.ds_map):
+            return self.ds_map[-1]
         fcl = self.ds_map[i_ds]
 
         # if we haven't already calculated, calculate for all files up to i_ds
@@ -384,6 +418,8 @@ class LH5Iterator(Iterator):
         """Helper to get cumulative iterator entries in file/groups"""
         if i_ds < 0:
             return 0
+        elif i_ds >= len(self.entry_map):
+            return self.entry_map[-1]
         n = self.entry_map[i_ds]
 
         # if we haven't already calculated, calculate for all files up to i_ds
@@ -468,16 +504,22 @@ class LH5Iterator(Iterator):
                 continue
 
             i_local = local_i_entry if local_idx is None else local_idx[local_i_entry]
-            self.lh5_buffer = self.lh5_st.read(
-                self.groups[i_ds],
-                self.lh5_files[i_ds],
-                start_row=i_local,
-                n_rows=n_entries - len(self.lh5_buffer),
-                idx=local_idx,
-                field_mask=self.field_mask,
-                obj_buf=self.lh5_buffer,
-                obj_buf_start=len(self.lh5_buffer),
-            )
+
+            if len(self.field_mask) > 0 or not isinstance(self.lh5_buffer, Table):
+                self.lh5_buffer = self.lh5_st.read(
+                    self.groups[i_ds],
+                    self.lh5_files[i_ds],
+                    start_row=i_local,
+                    n_rows=n_entries - len(self.lh5_buffer),
+                    idx=local_idx,
+                    field_mask=self.field_mask,
+                    obj_buf=self.lh5_buffer,
+                    obj_buf_start=len(self.lh5_buffer),
+                )
+            else:
+                self.lh5_buffer.resize(
+                    min(n_entries, self._get_ds_cumentries(i_ds) - i_entry)
+                )
 
             if self.group_data is not None:
                 data = self.group_data[i_ds]
@@ -491,6 +533,13 @@ class LH5Iterator(Iterator):
 
         for friend in self.friend:
             friend.read(i_entry)
+
+            if self.safe_mode and self._get_ds_cumentries(i_ds) == friend._get_ds_cumentries(i_ds) and np.any(self.entry_map[:i_ds] != friend.entry_map[:i_ds]):
+                i_diff = np.argmax(self.entry_map[:i_ds] != friend.entry_map[:i_ds])
+                msg = f"with safe_mode = True, require that datasets have same sizes between friends. "\
+                f"File {self.lh5_files[i_diff]} group {self.groups[i_diff]} differs from "\
+                f"file {friend.lh5_files[i_diff]} group {friend.groups[i_diff]}."
+                raise RuntimeError(msg)
 
         return self.lh5_buffer
 
@@ -531,6 +580,11 @@ class LH5Iterator(Iterator):
         if not isinstance(friend, LH5Iterator):
             msg = "Friend must be an LH5Iterator"
             raise ValueError(msg)
+        
+        if self.safe_mode and len(self.lh5_files) != len(friend.lh5_files):
+            msg = f"with safe_mode = True, friend iterator must have same number of datasets. "\
+            f"Found {len(self.lh5_files)} in self, and {len(friend.lh5_files)} in friend."
+            raise RuntimeError(msg)
 
         # set buffer_lens to be equal
         if friend.buffer_len > self.buffer_len:
@@ -573,11 +627,13 @@ class LH5Iterator(Iterator):
             for fr in self.friend:
                 fr.reset_field_mask(None)
 
-            remaining_fields = []
+            remaining_fields = set()
 
         elif isinstance(mask, Mapping):
             self.field_mask = {
-                field: mask[field] for field in self.available_fields if field in mask
+                field.replace(".", "/"): mask[field]
+                for field in self.available_fields
+                if field in mask
             }
             mask = {
                 field: mask[field] for field in mask if field not in self.field_mask
@@ -602,7 +658,7 @@ class LH5Iterator(Iterator):
             remaining_fields = mask
 
         elif isinstance(mask, Collection) and all(isinstance(m, str) for m in mask):
-            mask = set(mask)
+            mask = {f.replace(".", "/") for f in mask}
             self.field_mask = mask & set(self.available_fields)
             mask -= self.field_mask
 
@@ -627,15 +683,18 @@ class LH5Iterator(Iterator):
                 return new_buffer
             return old_buffer
 
-        self.lh5_buffer = copy_data(
-            self.lh5_buffer,
-            self.lh5_st.get_buffer(
-                self.groups[0],
-                self.lh5_files[0],
-                size=len(self.lh5_buffer),
-                field_mask=self.field_mask,
-            ),
-        )
+        if len(self.field_mask) > 0 or not isinstance(self.lh5_buffer, Table):
+            self.lh5_buffer = copy_data(
+                self.lh5_buffer,
+                self.lh5_st.get_buffer(
+                    self.groups[0],
+                    self.lh5_files[0],
+                    size=len(self.lh5_buffer),
+                    field_mask=self.field_mask,
+                ),
+            )
+        else:
+            self.lh5_buffer = Table(size=0)
 
         for fr, pre, suf in zip(
             self.friend, self.friend_prefix, self.friend_suffix, strict=False
@@ -648,9 +707,11 @@ class LH5Iterator(Iterator):
             )
 
         # join Table with group metadata; repeat first record to initialize
-        if self.group_data:
-            tb_gd = deepcopy(Table(ak.Array([self.group_data[0]])))
+        if self.group_data is not None:
+            # deepcopy required to prevent ownership conflict
+            tb_gd = deepcopy(Table(self.group_data[0:1], 1))
             tb_gd.resize(len(self.lh5_buffer))
+            remaining_fields -= set(tb_gd)
             self.lh5_buffer.join(tb_gd)
 
         if warn_missing and len(remaining_fields) > 0:
@@ -819,27 +880,25 @@ class LH5Iterator(Iterator):
         self.__dict__ = d
         self.lh5_st = LH5Store(**(d["lh5_st"]))
         self.lh5_st.gimme_file(self.lh5_files[0])
-        self.lh5_buffer = self.lh5_st.get_buffer(
-            self.groups[0],
-            self.lh5_files[0],
-            size=self.buffer_len,
-            field_mask=self.field_mask,
-        )
-        for fr, pre, suf in zip(
-            self.friend, self.friend_prefix, self.friend_suffix, strict=False
-        ):
-            self.lh5_buffer.join(
-                fr.lh5_buffer,
-                keep_mine=True,
-                prefix=pre,
-                suffix=suf,
-            )
+
+        self.lh5_buffer = Table(size=0)
+
+        # recursively walk through friends and append field_masks
+        def build_field_mask(it):
+            field_mask = it.field_mask
+            for fr in it.friend:
+                field_mask |= fr.field_mask
+            return field_mask
+
+        self.reset_field_mask(build_field_mask(self))
 
     def _select_groups(self, i_beg, i_end):
         """Reduce list of files and groups; used by _generate_workers"""
         s = slice(i_beg, i_end)
         self.lh5_files = self.lh5_files[s]
         self.groups = self.groups[s]
+        if self.group_data is not None:
+            self.group_data = self.group_data[s]
         self.n_datasets = i_end - i_beg
 
         if i_beg > 0:
@@ -1003,6 +1062,8 @@ class LH5Iterator(Iterator):
     def query(
         self,
         where: Callable | str,
+        *,
+        fields: Collection[str] | Mapping[str, str | None] = None,
         processes: Executor | int = None,
         executor: Executor = None,
         library: str = None,
@@ -1041,9 +1102,16 @@ class LH5Iterator(Iterator):
               - ``pandas.DataFrame``: pandas dataframe. Treat as mapping from column
                 name to values
 
-            - A string expression. This will call `Table.eval` to select events and
-                return a table with all fields in the `field_mask`, in a data format
-                provided with `library`.
+            - A string expression. This will call `eval`, with the table columns
+              provided as local variables formatted as :meth:`awkward.Array`, and
+              access to :module:`awkward` (or `ak`) and :module:`numpy` (or `np`).
+              Return a table formatted according to ``library``
+
+        fields:
+            list of fields to return. If ``None`` return all fields in ``field_mask``.
+            If a mapping is provided, key corresponds to name of field in this iterator,
+            and value is an alias to name in returned table; if alias is ``None``, do
+            not rename.
 
         processes:
             number of processes. If ``None``, use number equal to threads available
@@ -1060,7 +1128,7 @@ class LH5Iterator(Iterator):
             where = _identity
 
         if isinstance(where, str):
-            where = _table_query(where, library)
+            where = _table_query(where, library, fields)
 
         test = where(self.lh5_buffer, self)
         if isinstance(test, LGDOCollection):
@@ -1143,8 +1211,10 @@ class LH5Iterator(Iterator):
               - ``Collection[ArrayLike]``: return list of values in same order as axes
               - ``Mapping[str, ArrayLike]``: mapping from axis name to values
               - :class:`pandas.DataFrame`: treat as mapping from column name to values
-            - A string expression. This will call :meth:`lgdo.Table.eval` and return
-              a pandas DataFrame containing all columns in the fields mask.
+
+            - A string expression. This will call `eval`, with the table columns
+              provided as local variables formatted as :meth:`awkward.Array`, and
+              access to :module:`awkward` (or `ak`) and :module:`numpy` (or `np`)
 
         keys:
             list of keys fields corresponding to axes. Use if where
@@ -1157,7 +1227,7 @@ class LH5Iterator(Iterator):
             If ``None``, create a :class:`concurrent.futures.`ProcessPoolExecutor`
             with number of processes equal to ``processes``.
         hist_kwargs:
-            additional keyword arguments for constructing Hist. See :class:`hist.Hist`.
+            additional keyword arguments for constructing :class:`hist.Hist`.
         """
 
         # get initial hist for each thread
@@ -1172,7 +1242,7 @@ class LH5Iterator(Iterator):
         if where is None:
             where = _identity
         elif isinstance(where, str):
-            where = _table_query(where, "ak")
+            where = _table_query(where, "ak", None)
 
         h = self.map(
             where,
@@ -1229,18 +1299,33 @@ class _table_query:
 
     expr: str
     library: str
+    fields: Collection[str] | Mapping[str, str | None] | None
+
+    def __post_init__(self):
+        # turn collection into mapping
+        if self.fields is not None and not isinstance(self.fields, Mapping):
+            self.fields = { k:None for k in self.fields }
 
     def __call__(self, tab, _):
         "Evaluate selection and return selected elements"
-        # Note this could probably be done more simply if we
-        # implemented __getitem__ to work with lists/slices
-        mask = tab.eval(self.expr)
-        ret = tab.view_as("ak")[mask]
-        if self.library == "ak":
-            return ret
+        args = { f: a.view_as('ak', with_units = True) for f, a in tab.items() }
+        if self.fields is not None:
+            for k, v in self.fields.items():
+                if v is not None:
+                    args[v] = tab[k]
+
+        mask = eval(
+            self.expr,
+            {"np": np, "numpy": np, "ak": ak, "awkward": ak},
+            args,
+        )
+        ret = tab[mask]
+        if self.fields is not None:
+            ret = Table( { (k if f is None else f):ret[k] for k, f in self.fields.items() } )
+
         if self.library is None:
-            return Table(ret)
-        return Table(ret).view_as(self.library)
+            return ret
+        return ret.view_as(self.library, with_units=True)
 
 
 class _hist_filler:

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -13,10 +13,10 @@ import awkward as ak
 import numpy as np
 import pandas as pd
 from hist import Hist, axis
-from numpy.typing import NDArray
-
 from lgdo.types import LGDOCollection, Table
 from lgdo.units import default_units_registry as ureg
+from numpy.typing import NDArray
+
 from .store import LH5Store
 from .utils import expand_path
 
@@ -400,7 +400,7 @@ class LH5Iterator(Iterator):
         """Helper to get cumulative dataset length of file/groups"""
         if i_ds < 0:
             return 0
-        elif i_ds >= len(self.ds_map):
+        if i_ds >= len(self.ds_map):
             return self.ds_map[-1]
         fcl = self.ds_map[i_ds]
 
@@ -418,7 +418,7 @@ class LH5Iterator(Iterator):
         """Helper to get cumulative iterator entries in file/groups"""
         if i_ds < 0:
             return 0
-        elif i_ds >= len(self.entry_map):
+        if i_ds >= len(self.entry_map):
             return self.entry_map[-1]
         n = self.entry_map[i_ds]
 
@@ -534,11 +534,17 @@ class LH5Iterator(Iterator):
         for friend in self.friend:
             friend.read(i_entry)
 
-            if self.safe_mode and self._get_ds_cumentries(i_ds) == friend._get_ds_cumentries(i_ds) and np.any(self.entry_map[:i_ds] != friend.entry_map[:i_ds]):
+            if (
+                self.safe_mode
+                and self._get_ds_cumentries(i_ds) == friend._get_ds_cumentries(i_ds)
+                and np.any(self.entry_map[:i_ds] != friend.entry_map[:i_ds])
+            ):
                 i_diff = np.argmax(self.entry_map[:i_ds] != friend.entry_map[:i_ds])
-                msg = f"with safe_mode = True, require that datasets have same sizes between friends. "\
-                f"File {self.lh5_files[i_diff]} group {self.groups[i_diff]} differs from "\
-                f"file {friend.lh5_files[i_diff]} group {friend.groups[i_diff]}."
+                msg = (
+                    f"with safe_mode = True, require that datasets have same sizes between friends. "
+                    f"File {self.lh5_files[i_diff]} group {self.groups[i_diff]} differs from "
+                    f"file {friend.lh5_files[i_diff]} group {friend.groups[i_diff]}."
+                )
                 raise RuntimeError(msg)
 
         return self.lh5_buffer
@@ -580,10 +586,12 @@ class LH5Iterator(Iterator):
         if not isinstance(friend, LH5Iterator):
             msg = "Friend must be an LH5Iterator"
             raise ValueError(msg)
-        
+
         if self.safe_mode and len(self.lh5_files) != len(friend.lh5_files):
-            msg = f"with safe_mode = True, friend iterator must have same number of datasets. "\
-            f"Found {len(self.lh5_files)} in self, and {len(friend.lh5_files)} in friend."
+            msg = (
+                f"with safe_mode = True, friend iterator must have same number of datasets. "
+                f"Found {len(self.lh5_files)} in self, and {len(friend.lh5_files)} in friend."
+            )
             raise RuntimeError(msg)
 
         # set buffer_lens to be equal
@@ -1304,11 +1312,11 @@ class _table_query:
     def __post_init__(self):
         # turn collection into mapping
         if self.fields is not None and not isinstance(self.fields, Mapping):
-            self.fields = { k:None for k in self.fields }
+            self.fields = dict.fromkeys(self.fields)
 
     def __call__(self, tab, _):
         "Evaluate selection and return selected elements"
-        args = { f: a.view_as('ak', with_units = True) for f, a in tab.items() }
+        args = {f: a.view_as("ak", with_units=True) for f, a in tab.items()}
         if self.fields is not None:
             for k, v in self.fields.items():
                 if v is not None:
@@ -1321,7 +1329,9 @@ class _table_query:
         )
         ret = tab[mask]
         if self.fields is not None:
-            ret = Table( { (k if f is None else f):ret[k] for k, f in self.fields.items() } )
+            ret = Table(
+                {(k if f is None else f): ret[k] for k, f in self.fields.items()}
+            )
 
         if self.library is None:
             return ret

--- a/tests/lh5/test_lh5_iterator.py
+++ b/tests/lh5/test_lh5_iterator.py
@@ -4,14 +4,13 @@ import shutil
 from copy import deepcopy
 
 import awkward as ak
-import lgdo
 import numpy as np
 import pandas as pd
 import pytest
 from hist import axis
-from lgdo import Table
 
-import lh5
+from lh5 import LH5Iterator, read
+from lgdo import Array, Table, WaveformTable
 
 
 @pytest.fixture(scope="module")
@@ -20,7 +19,7 @@ def lgnd_file(lgnd_test_data):
 
 
 def test_basics(lgnd_file):
-    lh5_it = lh5.LH5Iterator(
+    lh5_it = LH5Iterator(
         lgnd_file,
         "/geds/raw",
         entry_list=range(100),
@@ -30,7 +29,7 @@ def test_basics(lgnd_file):
 
     lh5_obj = lh5_it.read(4)
     assert len(lh5_obj) == 5
-    assert isinstance(lh5_obj, lgdo.Table)
+    assert isinstance(lh5_obj, Table)
     assert list(lh5_obj.keys()) == ["baseline"]
     assert (
         lh5_obj["baseline"].nda == np.array([14353, 14254, 14525, 11656, 13576])
@@ -48,13 +47,13 @@ def test_basics(lgnd_file):
 
 def test_errors(lgnd_file):
     with pytest.raises(RuntimeError):
-        lh5.LH5Iterator("non-existent-file.lh5", "random-group")
+        LH5Iterator("non-existent-file.lh5", "random-group")
 
     with pytest.raises(ValueError):
-        lh5.LH5Iterator(1, 2)
+        LH5Iterator(1, 2)
 
     with pytest.raises(ValueError):
-        lh5.LH5Iterator(
+        LH5Iterator(
             lgnd_file,
             "/geds/raw",
             entry_list=range(100),
@@ -63,7 +62,7 @@ def test_errors(lgnd_file):
 
 
 def test_lgnd_waveform_table_fancy_idx(lgnd_file):
-    lh5_it = lh5.LH5Iterator(
+    lh5_it = LH5Iterator(
         lgnd_file,
         "geds/raw/waveform",
         entry_list=[
@@ -91,7 +90,7 @@ def test_lgnd_waveform_table_fancy_idx(lgnd_file):
     )
 
     lh5_obj = lh5_it.read(0)
-    assert isinstance(lh5_obj, lgdo.WaveformTable)
+    assert isinstance(lh5_obj, WaveformTable)
     assert len(lh5_obj) == 5
 
 
@@ -126,13 +125,13 @@ def more_lgnd_files(lgnd_test_data):
 
 
 def test_friend(more_lgnd_files):
-    lh5_raw_it = lh5.LH5Iterator(
+    lh5_raw_it = LH5Iterator(
         more_lgnd_files[0],
         "ch1084803/raw",
         field_mask=["waveform", "baseline"],
         buffer_len=5,
     )
-    lh5_it = lh5.LH5Iterator(
+    lh5_it = LH5Iterator(
         more_lgnd_files[2],
         "ch1084803/hit",
         field_mask=["is_valid_0vbb"],
@@ -143,19 +142,60 @@ def test_friend(more_lgnd_files):
     lh5_obj = lh5_it.read(0)
 
     assert len(lh5_obj) == 5
-    assert isinstance(lh5_obj, lgdo.Table)
+    assert isinstance(lh5_obj, Table)
     assert set(lh5_obj.keys()) == {"waveform", "baseline", "is_valid_0vbb"}
+
+    # test resetting field mask with friends
+    lh5_raw_it = LH5Iterator(
+        more_lgnd_files[0],
+        "ch1084803/raw",
+        buffer_len=5,
+    )
+    lh5_it = LH5Iterator(
+        more_lgnd_files[2],
+        "ch1084803/hit",
+        buffer_len=5,
+        friend=lh5_raw_it,
+    )
+    lh5_it.reset_field_mask(["waveform", "baseline", "is_valid_0vbb"])
+
+    lh5_obj = lh5_it.read(0)
+
+    assert len(lh5_obj) == 5
+    assert isinstance(lh5_obj, Table)
+    assert set(lh5_obj.keys()) == {"waveform", "baseline", "is_valid_0vbb"}
+
+    # test resetting field mask, leaving one friend with no fields
+    # test resetting field mask with friends
+    lh5_raw_it = LH5Iterator(
+        more_lgnd_files[0],
+        "ch1084803/raw",
+        buffer_len=5,
+    )
+    lh5_it = LH5Iterator(
+        more_lgnd_files[2],
+        "ch1084803/hit",
+        buffer_len=5,
+        friend=lh5_raw_it,
+    )
+    lh5_it.reset_field_mask(["waveform", "baseline"])
+
+    lh5_obj = lh5_it.read(0)
+
+    assert len(lh5_obj) == 5
+    assert isinstance(lh5_obj, Table)
+    assert set(lh5_obj.keys()) == {"waveform", "baseline"}
 
 
 def test_friend_conflict(more_lgnd_files):
-    lh5_raw_it = lh5.LH5Iterator(
+    lh5_raw_it = LH5Iterator(
         more_lgnd_files[0],
         "ch1084803/raw",
         field_mask=["waveform", "baseline"],
         buffer_len=5,
     )
 
-    lh5_it = lh5.LH5Iterator(
+    lh5_it = LH5Iterator(
         more_lgnd_files[1],
         "ch1084803/dsp",
         field_mask=["baseline", "wf_max"],
@@ -164,17 +204,17 @@ def test_friend_conflict(more_lgnd_files):
     )
     lh5_obj = lh5_it.read(0)
     assert set(lh5_obj.keys()) == {"waveform", "baseline", "wf_max"}
-    assert lh5_obj["waveform"] == lh5.read(
+    assert lh5_obj["waveform"] == read(
         "ch1084803/raw/waveform", more_lgnd_files[0], n_rows=5
     )
-    assert lh5_obj["baseline"] == lh5.read(
+    assert lh5_obj["baseline"] == read(
         "ch1084803/dsp/baseline", more_lgnd_files[1], n_rows=5
     )
-    assert lh5_obj["wf_max"] == lh5.read(
+    assert lh5_obj["wf_max"] == read(
         "ch1084803/dsp/wf_max", more_lgnd_files[1], n_rows=5
     )
 
-    lh5_it = lh5.LH5Iterator(
+    lh5_it = LH5Iterator(
         more_lgnd_files[1],
         "ch1084803/dsp",
         field_mask=["baseline", "wf_max"],
@@ -184,20 +224,20 @@ def test_friend_conflict(more_lgnd_files):
     )
     lh5_obj = lh5_it.read(0)
     assert set(lh5_obj.keys()) == {"raw_waveform", "raw_baseline", "baseline", "wf_max"}
-    assert lh5_obj["raw_waveform"] == lh5.read(
+    assert lh5_obj["raw_waveform"] == read(
         "ch1084803/raw/waveform", more_lgnd_files[0], n_rows=5
     )
-    assert lh5_obj["raw_baseline"] == lh5.read(
+    assert lh5_obj["raw_baseline"] == read(
         "ch1084803/raw/baseline", more_lgnd_files[0], n_rows=5
     )
-    assert lh5_obj["baseline"] == lh5.read(
+    assert lh5_obj["baseline"] == read(
         "ch1084803/dsp/baseline", more_lgnd_files[1], n_rows=5
     )
-    assert lh5_obj["wf_max"] == lh5.read(
+    assert lh5_obj["wf_max"] == read(
         "ch1084803/dsp/wf_max", more_lgnd_files[1], n_rows=5
     )
 
-    lh5_it = lh5.LH5Iterator(
+    lh5_it = LH5Iterator(
         more_lgnd_files[1],
         "ch1084803/dsp",
         field_mask=["baseline", "wf_max"],
@@ -207,29 +247,29 @@ def test_friend_conflict(more_lgnd_files):
     )
     lh5_obj = lh5_it.read(0)
     assert set(lh5_obj.keys()) == {"waveform_raw", "baseline_raw", "baseline", "wf_max"}
-    assert lh5_obj["waveform_raw"] == lh5.read(
+    assert lh5_obj["waveform_raw"] == read(
         "ch1084803/raw/waveform", more_lgnd_files[0], n_rows=5
     )
-    assert lh5_obj["baseline_raw"] == lh5.read(
+    assert lh5_obj["baseline_raw"] == read(
         "ch1084803/raw/baseline", more_lgnd_files[0], n_rows=5
     )
-    assert lh5_obj["baseline"] == lh5.read(
+    assert lh5_obj["baseline"] == read(
         "ch1084803/dsp/baseline", more_lgnd_files[1], n_rows=5
     )
-    assert lh5_obj["wf_max"] == lh5.read(
+    assert lh5_obj["wf_max"] == read(
         "ch1084803/dsp/wf_max", more_lgnd_files[1], n_rows=5
     )
 
     lh5_it.reset_field_mask(["waveform_raw", "baseline", "wf_max"])
     lh5_obj = lh5_it.read(0)
     assert set(lh5_obj.keys()) == {"waveform_raw", "baseline", "wf_max"}
-    assert lh5_obj["waveform_raw"] == lh5.read(
+    assert lh5_obj["waveform_raw"] == read(
         "ch1084803/raw/waveform", more_lgnd_files[0], n_rows=5
     )
-    assert lh5_obj["baseline"] == lh5.read(
+    assert lh5_obj["baseline"] == read(
         "ch1084803/dsp/baseline", more_lgnd_files[1], n_rows=5
     )
-    assert lh5_obj["wf_max"] == lh5.read(
+    assert lh5_obj["wf_max"] == read(
         "ch1084803/dsp/wf_max", more_lgnd_files[1], n_rows=5
     )
 
@@ -237,10 +277,10 @@ def test_friend_conflict(more_lgnd_files):
     lh5_obj = lh5_it.read(0)
     assert {"waveform_raw", "baseline"}.issubset(set(lh5_obj.keys()))
     assert {"baseline_raw", "wf_max"}.isdisjoint(set(lh5_obj.keys()))
-    assert lh5_obj["waveform_raw"] == lh5.read(
+    assert lh5_obj["waveform_raw"] == read(
         "ch1084803/raw/waveform", more_lgnd_files[0], n_rows=5
     )
-    assert lh5_obj["baseline"] == lh5.read(
+    assert lh5_obj["baseline"] == read(
         "ch1084803/dsp/baseline", more_lgnd_files[1], n_rows=5
     )
 
@@ -248,7 +288,7 @@ def test_friend_conflict(more_lgnd_files):
 def test_iterate(more_lgnd_files):
     # iterate through all hit groups in all files; there are 10 entries in
     # each group/file
-    lh5_it = lh5.LH5Iterator(
+    lh5_it = LH5Iterator(
         more_lgnd_files[2],
         ["ch1084803/hit", "ch1084804/hit", "ch1121600/hit"],
         field_mask=["is_valid_0vbb", "timestamp", "zacEmax_ctc_cal"],
@@ -283,7 +323,7 @@ def test_iterate(more_lgnd_files):
         assert all(lh5_it.current_files == exp_files[entry // 5])
         assert all(lh5_it.current_groups == exp_groups[entry // 5])
 
-    lh5_it = lh5.LH5Iterator(
+    lh5_it = LH5Iterator(
         more_lgnd_files[2],
         ["ch1084803/hit", "ch1084804/hit", "ch1121600/hit"],
         field_mask=["is_valid_0vbb", "timestamp", "zacEmax_ctc_cal"],
@@ -305,7 +345,7 @@ def test_iterate(more_lgnd_files):
         )
     )
 
-    lh5_it = lh5.LH5Iterator(
+    lh5_it = LH5Iterator(
         more_lgnd_files[2],
         [["ch1084803/hit", "ch1084804/hit"], ["ch1084803/hit", "ch1121600/hit"]],
         field_mask=["is_valid_0vbb", "timestamp", "zacEmax_ctc_cal"],
@@ -319,7 +359,7 @@ def test_iterate(more_lgnd_files):
 
     # different number of file sets and group sets
     with pytest.raises(ValueError):
-        lh5.LH5Iterator(
+        LH5Iterator(
             more_lgnd_files[2],
             [["ch1084803/hit", "ch1084804/hit"]],
             field_mask=["is_valid_0vbb", "timestamp", "zacEmax_ctc_cal"],
@@ -327,7 +367,7 @@ def test_iterate(more_lgnd_files):
         )
 
     with pytest.raises(ValueError):
-        lh5.LH5Iterator(
+        LH5Iterator(
             more_lgnd_files[2],
             [["ch1084803/hit"], ["ch1084804/hit"], ["ch1084803/hit"]],
             field_mask=["is_valid_0vbb", "timestamp", "zacEmax_ctc_cal"],
@@ -337,7 +377,7 @@ def test_iterate(more_lgnd_files):
 
 def test_group_data(more_lgnd_files):
     # test provision of metadata about groups
-    lh5_it = lh5.LH5Iterator(
+    lh5_it = LH5Iterator(
         more_lgnd_files[2],
         ["ch1084803/hit", "ch1084804/hit", "ch1121600/hit"],
         field_mask=["is_valid_0vbb", "timestamp", "zacEmax_ctc_cal"],
@@ -368,18 +408,18 @@ def test_group_data(more_lgnd_files):
         }
         assert all(tb.chan.nda == ec)
 
-    # group_data must be same shape as field_mask
+    # group_data must be same shape as froup_list
     with pytest.raises(ValueError):
-        lh5_it = lh5.LH5Iterator(
+        lh5_it = LH5Iterator(
             more_lgnd_files[2],
             ["ch1084803/hit", "ch1084804/hit", "ch1121600/hit"],
             field_mask=["is_valid_0vbb", "timestamp", "zacEmax_ctc_cal"],
             buffer_len=5,
-            group_data={"chan": [1084803, 1084804, 1121600, 1234567]},
+            group_data={"chan": [1084803, 1084804, 1121600, 1234567, 9876543]},
         )
 
     # group_data provided using pandas dataframe
-    lh5_it = lh5.LH5Iterator(
+    lh5_it = LH5Iterator(
         more_lgnd_files[2],
         ["ch1084803/hit", "ch1084804/hit", "ch1121600/hit"],
         field_mask=["is_valid_0vbb", "timestamp", "zacEmax_ctc_cal"],
@@ -396,7 +436,7 @@ def test_group_data(more_lgnd_files):
         assert all(tb.chan.nda == ec)
 
     # group_data provided using awkward array as array of records
-    lh5_it = lh5.LH5Iterator(
+    lh5_it = LH5Iterator(
         more_lgnd_files[2],
         ["ch1084803/hit", "ch1084804/hit", "ch1121600/hit"],
         field_mask=["is_valid_0vbb", "timestamp", "zacEmax_ctc_cal"],
@@ -414,9 +454,66 @@ def test_group_data(more_lgnd_files):
         }
         assert all(tb.chan.nda == ec)
 
+    # test broadcasting of group data
+    lh5_it = LH5Iterator(
+        more_lgnd_files[2],
+        ["ch1084803/hit", "ch1084804/hit", "ch1121600/hit"],
+        field_mask=["is_valid_0vbb", "timestamp", "zacEmax_ctc_cal"],
+        buffer_len=5,
+        group_data={"chan": [1084803, 1084804, 1121600], "type": "geds"},
+    )
+    for tb, ec in zip(lh5_it, exp_chan, strict=False):
+        assert set(tb.keys()) == {
+            "is_valid_0vbb",
+            "timestamp",
+            "zacEmax_ctc_cal",
+            "chan",
+            "type",
+        }
+        assert all(tb.chan.nda == ec)
+        assert all(tb.type.nda == "geds")
+
+    # group_data that differs for each run
+    exp_chan = [
+        [1084803] * 5,
+        [1084803] * 5,
+        [1084804] * 5,
+        [1084804] * 5,
+        [1121600] * 5,
+        [1121600] * 5,
+        [2084803] * 5,
+        [2084803] * 5,
+        [2084804] * 5,
+        [2084804] * 5,
+        [2121600] * 5,
+        [2121600] * 5,
+    ]
+    exp_type = ["geds"] * 6 + ["gedss"] * 6
+
+    lh5_it = LH5Iterator(
+        more_lgnd_files[2],
+        ["ch1084803/hit", "ch1084804/hit", "ch1121600/hit"],
+        field_mask=["is_valid_0vbb", "timestamp", "zacEmax_ctc_cal"],
+        buffer_len=5,
+        group_data={
+            "chan": [[1084803, 1084804, 1121600], [2084803, 2084804, 2121600]],
+            "type": ["geds", "gedss"],
+        },
+    )
+    for tb, ec, et in zip(lh5_it, exp_chan, exp_type, strict=False):
+        assert set(tb.keys()) == {
+            "is_valid_0vbb",
+            "timestamp",
+            "zacEmax_ctc_cal",
+            "chan",
+            "type",
+        }
+        assert all(tb.chan.nda == ec)
+        assert all(tb.type.nda == et)
+
 
 def test_range(lgnd_file):
-    lh5_it = lh5.LH5Iterator(
+    lh5_it = LH5Iterator(
         lgnd_file,
         "/geds/raw",
         field_mask=["baseline"],
@@ -431,7 +528,7 @@ def test_range(lgnd_file):
 
     lh5_obj = lh5_it.read(4, n_entries=3)
     assert len(lh5_obj) == 3
-    assert isinstance(lh5_obj, lgdo.Table)
+    assert isinstance(lh5_obj, Table)
     assert list(lh5_obj.keys()) == ["baseline"]
     assert (lh5_obj["baseline"].nda == np.array([14353, 14254, 14525])).all()
 
@@ -455,7 +552,7 @@ def return_tb(tb, _):
 def test_map(more_lgnd_files):
     # iterate through all hit groups in all files; there are 10 entries in
     # each group/file
-    lh5_it = lh5.LH5Iterator(
+    lh5_it = LH5Iterator(
         more_lgnd_files[2],
         ["ch1084803/hit", "ch1084804/hit", "ch1121600/hit"],
         field_mask=["is_valid_0vbb", "timestamp", "zacEmax_ctc_cal"],
@@ -521,7 +618,7 @@ def query_np(tb, _):
 
 
 def test_query(more_lgnd_files):
-    lh5_it = lh5.LH5Iterator(
+    lh5_it = LH5Iterator(
         more_lgnd_files[2],
         ["ch1084803/hit", "ch1084804/hit", "ch1121600/hit"],
         field_mask=["is_valid_0vbb", "timestamp", "zacEmax_ctc_cal"],
@@ -543,6 +640,21 @@ def test_query(more_lgnd_files):
     tb_lgdo_mp = lh5_it.query(query_lgdo, processes=3)
     assert tb_lgdo_mp == tb_exp
 
+    tb_lgdo = lh5_it.query("zacEmax_ctc_cal>200")
+    assert tb_lgdo == tb_exp
+    tb_lgdo_mp = lh5_it.query("zacEmax_ctc_cal>200", processes=3)
+    assert tb_lgdo_mp == tb_exp
+
+    tb_lgdo = lh5_it.query("zacEmax_ctc_cal>200", fields=["timestamp"])
+    assert tb_lgdo == Table({"timestamp": tb_exp["timestamp"]})
+    tb_lgdo_mp = lh5_it.query("zacEmax_ctc_cal>200", fields=["timestamp"], processes=3)
+    assert tb_lgdo_mp == Table({"timestamp": tb_exp["timestamp"]})
+
+    tb_lgdo = lh5_it.query("zacEmax_ctc_cal>200", fields={"timestamp":None, "zacEmax_ctc_cal":"energy"})
+    assert tb_lgdo == Table({"timestamp": tb_exp["timestamp"], "energy": tb_exp["zacEmax_ctc_cal"]})
+    tb_lgdo_mp = lh5_it.query("zacEmax_ctc_cal>200", fields={"timestamp":None, "zacEmax_ctc_cal":"energy"}, processes=3)
+    assert tb_lgdo_mp == Table({"timestamp": tb_exp["timestamp"], "energy": tb_exp["zacEmax_ctc_cal"]})
+
     pd_out = lh5_it.query(query_pd)
     assert pd_out.equals(tb_exp.view_as("pd"))
     pd_out_mp = lh5_it.query(query_pd, processes=3)
@@ -558,14 +670,9 @@ def test_query(more_lgnd_files):
     np_out_mp = lh5_it.query(query_np, processes=3)
     assert np.all(np_out_mp == tb_exp["zacEmax_ctc_cal"])
 
-    pd_out_str = lh5_it.query("zacEmax_ctc_cal>200", library="pd")
-    assert pd_out_str.equals(tb_exp.view_as("pd"))
-    pd_out_str_mp = lh5_it.query("zacEmax_ctc_cal>200", processes=3, library="pd")
-    assert pd_out_str_mp.equals(tb_exp.view_as("pd"))
-
 
 def test_hist(more_lgnd_files):
-    lh5_it = lh5.LH5Iterator(
+    lh5_it = LH5Iterator(
         more_lgnd_files[2],
         ["ch1084803/hit", "ch1084804/hit", "ch1121600/hit"],
         field_mask=["timestamp", "zacEmax_ctc_cal"],
@@ -664,12 +771,12 @@ def test_hist(more_lgnd_files):
 def test_iterator_wo_mode_write(tmp_path, lh5_file):
     dst = tmp_path / "rw.lh5"
     shutil.copy(lh5_file, dst)
-    it = lh5.LH5Iterator(
+    it = LH5Iterator(
         dst.as_posix(), "/data/struct_full/array", h5py_open_mode="append"
     )
     store = it.lh5_st
     store.write(
-        lgdo.Array(nda=np.array([0], dtype=int)),
+        Array(nda=np.array([0], dtype=int)),
         "dummy",
         dst.as_posix(),
         group="/data",
@@ -679,11 +786,52 @@ def test_iterator_wo_mode_write(tmp_path, lh5_file):
     assert len(it.read(0)) > 0
 
 
-def test_lh5_iterator_view_as(lgnd_test_data):
-    it = lh5.LH5Iterator(
-        lgnd_test_data.get_path("lh5/l200-p03-r000-phy-20230312T055349Z-tier_psp.lh5"),
-        "ch1067205/dsp/energies",
+def test_safe_mode(more_lgnd_files):
+    lh5_raw_it = LH5Iterator(
+        more_lgnd_files[0],
+        ["ch1084803/raw", "ch1084804/raw"],
+        field_mask=["waveform", "baseline"],
+        buffer_len=5,
+    )
+    with pytest.raises(RuntimeError):
+        lh5_it = LH5Iterator(
+            more_lgnd_files[2],
+            ["ch1084803/hit", "ch1084804/hit", "ch1121600/hit"],
+            field_mask=["is_valid_0vbb"],
+            buffer_len=5,
+            friend=lh5_raw_it,
+        )
+
+    lh5_raw_it = LH5Iterator(
+        more_lgnd_files[0],
+        ["ch1084803/raw", "ch1084804/raw"],
+        field_mask=["waveform", "baseline"],
+        buffer_len=5,
+    )
+    lh5_it = LH5Iterator(
+        more_lgnd_files[2],
+        ["ch1084803/hit", "ch1084804/hit", "ch1121600/hit"],
+        field_mask=["is_valid_0vbb"],
+        buffer_len=5,
+        friend=lh5_raw_it,
+        safe_mode=False,
     )
 
-    for obj in it:
-        assert ak.is_valid(obj.view_as("ak"))
+    lh5_raw_it = LH5Iterator(
+        more_lgnd_files[0],
+        ["ch1084803/raw"],
+        entry_list = [1, 3, 5, 7, 9, 11, 13],
+        field_mask=["waveform", "baseline"],
+        buffer_len=5,
+    )
+    lh5_it = LH5Iterator(
+        more_lgnd_files[2],
+        ["ch1084803/hit"],
+        entry_list = [1, 3, 5, 9, 11, 13],
+        field_mask=["is_valid_0vbb"],
+        buffer_len=5,
+        friend=lh5_raw_it,
+    )
+    with pytest.raises(RuntimeError):
+        for _ in lh5_it:
+            pass

--- a/tests/lh5/test_lh5_iterator.py
+++ b/tests/lh5/test_lh5_iterator.py
@@ -408,7 +408,7 @@ def test_group_data(more_lgnd_files):
         }
         assert all(tb.chan.nda == ec)
 
-    # group_data must be same shape as froup_list
+    # group_data must be same shape as group_list
     with pytest.raises(ValueError):
         lh5_it = LH5Iterator(
             more_lgnd_files[2],

--- a/tests/lh5/test_lh5_iterator.py
+++ b/tests/lh5/test_lh5_iterator.py
@@ -8,9 +8,9 @@ import numpy as np
 import pandas as pd
 import pytest
 from hist import axis
+from lgdo import Array, Table, WaveformTable
 
 from lh5 import LH5Iterator, read
-from lgdo import Array, Table, WaveformTable
 
 
 @pytest.fixture(scope="module")
@@ -650,10 +650,20 @@ def test_query(more_lgnd_files):
     tb_lgdo_mp = lh5_it.query("zacEmax_ctc_cal>200", fields=["timestamp"], processes=3)
     assert tb_lgdo_mp == Table({"timestamp": tb_exp["timestamp"]})
 
-    tb_lgdo = lh5_it.query("zacEmax_ctc_cal>200", fields={"timestamp":None, "zacEmax_ctc_cal":"energy"})
-    assert tb_lgdo == Table({"timestamp": tb_exp["timestamp"], "energy": tb_exp["zacEmax_ctc_cal"]})
-    tb_lgdo_mp = lh5_it.query("zacEmax_ctc_cal>200", fields={"timestamp":None, "zacEmax_ctc_cal":"energy"}, processes=3)
-    assert tb_lgdo_mp == Table({"timestamp": tb_exp["timestamp"], "energy": tb_exp["zacEmax_ctc_cal"]})
+    tb_lgdo = lh5_it.query(
+        "zacEmax_ctc_cal>200", fields={"timestamp": None, "zacEmax_ctc_cal": "energy"}
+    )
+    assert tb_lgdo == Table(
+        {"timestamp": tb_exp["timestamp"], "energy": tb_exp["zacEmax_ctc_cal"]}
+    )
+    tb_lgdo_mp = lh5_it.query(
+        "zacEmax_ctc_cal>200",
+        fields={"timestamp": None, "zacEmax_ctc_cal": "energy"},
+        processes=3,
+    )
+    assert tb_lgdo_mp == Table(
+        {"timestamp": tb_exp["timestamp"], "energy": tb_exp["zacEmax_ctc_cal"]}
+    )
 
     pd_out = lh5_it.query(query_pd)
     assert pd_out.equals(tb_exp.view_as("pd"))
@@ -771,9 +781,7 @@ def test_hist(more_lgnd_files):
 def test_iterator_wo_mode_write(tmp_path, lh5_file):
     dst = tmp_path / "rw.lh5"
     shutil.copy(lh5_file, dst)
-    it = LH5Iterator(
-        dst.as_posix(), "/data/struct_full/array", h5py_open_mode="append"
-    )
+    it = LH5Iterator(dst.as_posix(), "/data/struct_full/array", h5py_open_mode="append")
     store = it.lh5_st
     store.write(
         Array(nda=np.array([0], dtype=int)),
@@ -820,14 +828,14 @@ def test_safe_mode(more_lgnd_files):
     lh5_raw_it = LH5Iterator(
         more_lgnd_files[0],
         ["ch1084803/raw"],
-        entry_list = [1, 3, 5, 7, 9, 11, 13],
+        entry_list=[1, 3, 5, 7, 9, 11, 13],
         field_mask=["waveform", "baseline"],
         buffer_len=5,
     )
     lh5_it = LH5Iterator(
         more_lgnd_files[2],
         ["ch1084803/hit"],
-        entry_list = [1, 3, 5, 9, 11, 13],
+        entry_list=[1, 3, 5, 9, 11, 13],
         field_mask=["is_valid_0vbb"],
         buffer_len=5,
         friend=lh5_raw_it,

--- a/tests/lh5/test_lh5_store.py
+++ b/tests/lh5/test_lh5_store.py
@@ -484,14 +484,41 @@ def test_read_with_field_mask(lh5_file):
 def test_read_with_nested_field_mask(lh5_file):
     store = lh5.LH5Store()
 
-    lh5_obj = store.read("/data", lh5_file, field_mask=["struct/table"])
+    lh5_obj = store.read(
+        "/data", lh5_file, decompress=False, field_mask=["struct/table"]
+    )
     assert sorted(lh5_obj.struct.keys()) == ["table"]
+    assert sorted(lh5_obj.struct.table.keys()) == ["a", "b", "c", "d"]
 
     lh5_obj = store.read("/data", lh5_file, field_mask=["struct/table/a"])
     assert sorted(lh5_obj.struct.table.keys()) == ["a"]
 
     lh5_obj = store.read(
         "/data", lh5_file, decompress=False, field_mask={"struct/table/b": False}
+    )
+    assert sorted(lh5_obj.struct.table.keys()) == ["a", "c", "d"]
+
+    lh5_obj = store.read(
+        "/data",
+        lh5_file,
+        decompress=False,
+        field_mask=["struct/table", "struct/table/b"],
+    )
+    assert sorted(lh5_obj.struct.table.keys()) == ["a", "b", "c", "d"]
+
+    lh5_obj = store.read(
+        "/data",
+        lh5_file,
+        decompress=False,
+        field_mask={"struct/table": False, "struct/table/b": True},
+    )
+    assert sorted(lh5_obj.struct.table.keys()) == ["b"]
+
+    lh5_obj = store.read(
+        "/data",
+        lh5_file,
+        decompress=False,
+        field_mask={"struct/table": True, "struct/table/b": False},
     )
     assert sorted(lh5_obj.struct.table.keys()) == ["a", "c", "d"]
 

--- a/tests/lh5/test_truncate.py
+++ b/tests/lh5/test_truncate.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import awkward as ak
-from lgdo import lh5, read_as
 
-from lh5.io import concat
+import lh5
+from lh5.io import concat, read_as
 from lh5.io.truncate import truncate
 
 


### PR DESCRIPTION
Changes to LH5Iterator, aimed at helping with data querying

- Fixed bugs that cause errors and warnings when a field_mask for an LH5Iterator is empty
- Use . in addition to / to separate attributes in variables for field mask (as is done for Table)
- Improve broadcasting of group_data so that you can have a single value broadcast over all groups (e.g. run information) rather than needing to provide a separate value for each group
- Enable selecting a subset of fields to return in query. Fields may be provided as a collection, or as a Mapping in which case aliases may be assigned to fields
- In query, do not cast to Table before applying mask
- Added safe_mode as a constructor argument. When using safe_mode, check that any friended iterators have identical structure, i.e. same number of files and same size for each file. Raise an exception if this is not the case

Depends on https://github.com/legend-exp/legend-pydataobj/pull/212