### PR TITLE
fix: resolve broken __all__ entries and add import test

### DIFF
--- a/src/lh5/io/__init__.py
+++ b/src/lh5/io/__init__.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 # filters
 import hdf5plugin  # noqa: F401
 
+from . import concat, truncate
 from .core import read, read_as, write
 from .iterator import LH5Iterator
+from .settings import default_hdf5_settings
 from .store import LH5Store
 from .tools import ls, show
 from .utils import read_n_rows
@@ -26,7 +28,6 @@ __all__ = [
     "read",
     "read_as",
     "read_n_rows",
-    "reset_default_hdf5_settings",
     "show",
     "truncate",
     "write",

--- a/src/lh5/io/_serializers/__init__.py
+++ b/src/lh5/io/_serializers/__init__.py
@@ -14,6 +14,7 @@ from .read.composite import (
 )
 from .read.encoded import (
     _h5_read_array_of_encoded_equalsized_arrays,
+    _h5_read_encoded_array,
     _h5_read_vector_of_encoded_vectors,
 )
 from .read.scalar import _h5_read_scalar

--- a/src/lh5/io/concat.py
+++ b/src/lh5/io/concat.py
@@ -5,7 +5,9 @@ import logging
 
 from lgdo.types import Array, Scalar, Struct, Table, VectorOfVectors
 
-import lh5
+from .iterator import LH5Iterator
+from .store import LH5Store
+from .tools import ls
 
 log = logging.getLogger(__name__)
 
@@ -26,7 +28,7 @@ def _get_obj_list(
 
     """
     file0 = lh5_files[0]
-    obj_list_full = set(lh5.ls(file0, recursive=True))
+    obj_list_full = set(ls(file0, recursive=True))
 
     # let's remove objects with nested LGDOs inside
     to_remove = set()
@@ -55,7 +57,7 @@ def _get_obj_list(
 def _get_lgdos(file, obj_list):
     """Get name of LGDO objects."""
 
-    store = lh5.LH5Store()
+    store = LH5Store()
     h5f0 = store.gimme_file(file)
 
     lgdos = []
@@ -175,12 +177,12 @@ def lh5concat(
 
     lgdos, lgdo_structs = _get_lgdos(lh5_files[0], obj_list)
     first_done = False
-    store = lh5.LH5Store()
+    store = LH5Store()
 
     # loop over lgdo objects
     for lgdo in lgdos:
         # iterate over the files
-        for lh5_obj in lh5.LH5Iterator(lh5_files, lgdo):
+        for lh5_obj in LH5Iterator(lh5_files, lgdo):
             data = {lgdo: lh5_obj}
 
             # remove the nested fields

--- a/src/lh5/io/truncate.py
+++ b/src/lh5/io/truncate.py
@@ -11,8 +11,9 @@ from typing import Protocol
 import awkward as ak
 from lgdo.types import LGDO, Array, Struct, Table, VectorOfVectors, WaveformTable
 
-import lh5
-from lh5 import read, read_as
+from .core import read, read_as
+from .store import LH5Store
+from .tools import ls
 
 log = logging.getLogger(__name__)
 
@@ -151,13 +152,13 @@ def map_lgdo_arrays_on_file(
 
     # list of root lgdo names. Actually 2nd level, since / is the real root.
     # But I don't want to load all at once for memory reasons.
-    root_lgdo_names = lh5.ls(infile, recursive=False)
+    root_lgdo_names = ls(infile, recursive=False)
 
     msg = f"objects in {infile}: {root_lgdo_names}"
     log.info(msg)
 
     first_done = False
-    store = lh5.LH5Store()
+    store = LH5Store()
 
     # loop over lgdo objects
     for root_name in root_lgdo_names:

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,36 @@
+"""Verify the package and its subpackages import cleanly and that every name
+listed in ``__all__`` is actually exposed.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+
+import pytest
+
+import lh5
+
+SUBMODULES = [
+    name
+    for _, name, _ in pkgutil.walk_packages(lh5.__path__, prefix=lh5.__name__ + ".")
+]
+
+
+@pytest.mark.parametrize("modname", [lh5.__name__, *SUBMODULES])
+def test_module_importable(modname):
+    importlib.import_module(modname)
+
+
+@pytest.mark.parametrize("modname", [lh5.__name__, *SUBMODULES])
+def test_all_names_resolved(modname):
+    mod = importlib.import_module(modname)
+    for name in getattr(mod, "__all__", []):
+        assert hasattr(mod, name), f"{modname}.__all__ lists missing name {name!r}"
+
+
+def test_top_level_star_import():
+    namespace: dict = {}
+    exec("from lh5 import *", namespace)
+    for name in lh5.__all__:
+        assert name in namespace


### PR DESCRIPTION
## Summary
- Fix `__all__` entries in `lh5.io` and `lh5.io._serializers` that referenced names not actually exposed by the module — including `reset_default_hdf5_settings`, which never existed in the codebase.
- Add proper imports for `concat`, `truncate`, `default_hdf5_settings`, and `_h5_read_encoded_array`.
- Replace top-level `import lh5` in `lh5/io/concat.py` and `lh5/io/truncate.py` with intra-package relative imports to break the resulting circular import.
- Add `tests/test_imports.py` which walks every submodule via `pkgutil.walk_packages` and verifies (a) each module imports cleanly and (b) every name in its `__all__` resolves.

## Test plan
- [x] `pytest tests/test_imports.py` — 71 cases pass
- [x] `pytest tests/lh5/test_concat.py tests/lh5/test_truncate.py` — still pass after the relative-import rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)