### PR TITLE
iterator: fix crash when first file has empty objects

### DIFF
--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -558,13 +558,16 @@ class LH5Iterator(Iterator):
         if isinstance(buffer_len, str):
             buffer_len = ureg.Quantity(buffer_len)
         if isinstance(buffer_len, ureg.Quantity):
-            f = self.lh5_files[0]
+            # in some edge cases, we might have no data in some of the files for some of the group(s).
             g = self.groups[0]
-            buffer_len = int(
-                buffer_len
-                / (self.lh5_st.read_size_in_bytes(g, f) * ureg.B)
-                * self.lh5_st.read_n_rows(g, f)
-            )
+            sizes_in_bytes = {}
+            for f in self.lh5_files:
+                n_row = max(self.lh5_st.read_n_rows(g, f), 1)
+                sizes_in_bytes[f] = self.lh5_st.read_size_in_bytes(g, f) / n_row
+            size_in_bytes = max(sizes_in_bytes.values())
+
+            if size_in_bytes > 0:
+                buffer_len = int(buffer_len / (size_in_bytes * ureg.B))
 
         self._buffer_len = buffer_len
         for fr in self.friend:

--- a/tests/lh5/test_concat.py
+++ b/tests/lh5/test_concat.py
@@ -164,3 +164,17 @@ def test_concat(lgnd_test_data, tmptestdir):
     # check for reasonable failures
     with pytest.raises(RuntimeError):
         concat.lh5concat(output=outfile, lh5_files=[infile1], overwrite=True)
+
+
+def test_concat_empty(tmptestdir):
+    infile1 = f"{tmptestdir}/in1.lh5"
+    tab1 = types.Table({"a": types.Array(np.array([]))})
+    lh5.write(tab1, "/tab", infile1, wo_mode="of")
+
+    infile2 = f"{tmptestdir}/in2.lh5"
+    tab2 = types.Table({"a": types.Array(np.array([0, 1, 2]))})
+    lh5.write(tab2, "/tab", infile2, wo_mode="of")
+
+    # this should not crash if the first file has an empty table.
+    outfile = f"{tmptestdir}/out.lh5"
+    concat.lh5concat(output=outfile, lh5_files=[infile1, infile2], overwrite=True)


### PR DESCRIPTION
fixes #19 

this fixes lh5concat when some empty objects are present in the first file