### PR TITLE
io: warn when field_mask references unknown fields

### DIFF
--- a/src/lh5/io/_serializers/read/composite.py
+++ b/src/lh5/io/_serializers/read/composite.py
@@ -268,7 +268,7 @@ def _h5_read_struct(
 
     # determine fields to be read out
     all_fields = dtypeutils.get_struct_fields(attrs["datatype"])
-    selected_fields = utils.eval_field_mask(field_mask, all_fields)
+    selected_fields = utils.eval_field_mask(field_mask, all_fields, fname, oname)
 
     # modify datatype in attrs if a field_mask was used
     attrs["datatype"] = (
@@ -316,7 +316,7 @@ def _h5_read_table(
 
     # determine fields to be read out
     all_fields = dtypeutils.get_struct_fields(attrs["datatype"])
-    selected_fields = utils.eval_field_mask(field_mask, all_fields)
+    selected_fields = utils.eval_field_mask(field_mask, all_fields, fname, oname)
 
     # modify datatype in attrs if a field_mask was used
     attrs["datatype"] = "table{" + ",".join(field for field, _ in selected_fields) + "}"

--- a/src/lh5/io/_serializers/read/utils.py
+++ b/src/lh5/io/_serializers/read/utils.py
@@ -42,10 +42,13 @@ def build_field_mask(field_mask: Mapping[str, bool] | Collection[str]) -> defaul
 
 
 def eval_field_mask(
-    field_mask: defaultdict, all_fields: list[str]
-) -> list[tuple(str, defaultdict)]:
+    field_mask: defaultdict,
+    all_fields: list[str],
+    fname: str | None = None,
+    oname: str | None = None,
+) -> list[tuple[str, defaultdict | None]]:
     """Get list of fields that need to be loaded along with a sub-field-mask
-    in case we have a nested Table"""
+    for any nested ``Struct`` or ``Table``."""
 
     if field_mask is None:
         return all_fields
@@ -79,6 +82,24 @@ def eval_field_mask(
                 )
 
             this_field_mask[field] |= val
+
+    available = set(all_fields)
+    for field in this_field_mask:
+        if field not in available:
+            if fname and oname:
+                location = f"{fname}[{oname}]"
+            elif fname:
+                location = fname
+            elif oname:
+                location = oname
+            else:
+                location = "object"
+            log.warning(
+                "field %r specified in field_mask not found in %s (known fields: %s)",
+                field,
+                location,
+                all_fields,
+            )
 
     return [
         (field, sub_field_masks.get(field))
@@ -202,7 +223,7 @@ def read_size_in_bytes(h5o, fname, oname, field_mask=None):
         # read out each of the fields
         size = 0
         all_fields = datatype.get_struct_fields(type_attr)
-        selected_fields = eval_field_mask(field_mask, all_fields)
+        selected_fields = eval_field_mask(field_mask, all_fields, fname, oname)
         for field, submask in selected_fields:
             obj = h5py.h5o.open(h5o, field.encode())
             size += read_size_in_bytes(obj, fname, field, submask)


### PR DESCRIPTION
## Summary
- `lh5.read(..., field_mask=[...])` previously ignored field-mask entries that didn't match any field of the LH5 object being read.
- `eval_field_mask` now emits a `log.warning` for any top-level key not present in the object's fields, reporting the file/object path and the list of known fields.
- Nested mismatches (e.g. `table/missing_col`) are caught when the recursion descends into the parent.

## Test plan
- [x] Existing `test_read_with_field_mask` / `test_read_with_nested_field_mask` pass.
- [x] Existing `test_lh5_iterator` suite passes.
- [x] Manual: `lh5.read(..., field_mask=['nonexistent'])` now logs a warning and still returns an empty result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)