### PR TITLE
cli: fix --verbose not enabling log messages

### DIFF
--- a/src/lh5/cli.py
+++ b/src/lh5/cli.py
@@ -64,6 +64,7 @@ def lh5ls(args=None):
     args = parser.parse_args(args)
 
     if args.verbose:
+        lgdogging.setup(logging.DEBUG, logging.getLogger("lh5"))
         lgdogging.setup(logging.DEBUG, logging.getLogger("lgdo"))
     elif args.debug:
         lgdogging.setup(logging.DEBUG, logging.root)
@@ -164,6 +165,7 @@ Exclude the /data/table1/col1 Table column:
     args = parser.parse_args(args)
 
     if args.verbose:
+        lgdogging.setup(logging.INFO, logging.getLogger("lh5"))
         lgdogging.setup(logging.INFO, logging.getLogger("lgdo"))
     elif args.debug:
         lgdogging.setup(logging.DEBUG, logging.root)
@@ -276,6 +278,7 @@ Include only specific paths:
     args = parser.parse_args(args)
 
     if args.verbose:
+        lgdogging.setup(logging.INFO, logging.getLogger("lh5"))
         lgdogging.setup(logging.INFO, logging.getLogger("lgdo"))
     elif args.debug:
         lgdogging.setup(logging.DEBUG, logging.root)

--- a/src/lh5/cli.py
+++ b/src/lh5/cli.py
@@ -65,7 +65,6 @@ def lh5ls(args=None):
 
     if args.verbose:
         lgdogging.setup(logging.DEBUG, logging.getLogger("lh5"))
-        lgdogging.setup(logging.DEBUG, logging.getLogger("lgdo"))
     elif args.debug:
         lgdogging.setup(logging.DEBUG, logging.root)
     else:
@@ -166,7 +165,6 @@ Exclude the /data/table1/col1 Table column:
 
     if args.verbose:
         lgdogging.setup(logging.INFO, logging.getLogger("lh5"))
-        lgdogging.setup(logging.INFO, logging.getLogger("lgdo"))
     elif args.debug:
         lgdogging.setup(logging.DEBUG, logging.root)
     else:
@@ -279,7 +277,6 @@ Include only specific paths:
 
     if args.verbose:
         lgdogging.setup(logging.INFO, logging.getLogger("lh5"))
-        lgdogging.setup(logging.INFO, logging.getLogger("lgdo"))
     elif args.debug:
         lgdogging.setup(logging.DEBUG, logging.root)
     else:


### PR DESCRIPTION
## Summary
- `lh5ls`, `lh5concat` and `lh5truncate` accept `--verbose` / `-v`, but the flag previously had no visible effect: the handler was only installed on the `lgdo` logger, while the actual messages emitted by `lh5.io.concat`, `lh5.io.truncate` and `lh5.io.tools` live on the `lh5.*` logger hierarchy, which had no handler attached.
- The CLI entry points now configure the `lh5` logger on `--verbose` (INFO for `lh5concat`/`lh5truncate`, DEBUG for `lh5ls`, matching the prior intent).
- The `lgdo` logger is no longer set up implicitly by these CLIs — see commit 2.

## Commits
1. `cli: fix --verbose not enabling lh5 log messages` — adds the `lh5` logger setup alongside `lgdo`.
2. `cli: drop lgdo logger setup from --verbose` — removes the `lgdo` setup; this package's CLIs shouldn't enable lgdo logging implicitly.

## Test plan
- [x] Manual: `lh5concat -v -o out.lh5 -w a.lh5 b.lh5` now prints the INFO messages from `lh5.io.concat` (object discovery, output creation, …).
- [x] Without `-v`: silent (matches prior behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)