### PR TITLE
lh5concat: progress bar and missing-object fix

### DIFF
--- a/src/lh5/cli.py
+++ b/src/lh5/cli.py
@@ -70,6 +70,7 @@ def lh5ls(args=None):
         lgdogging.setup(logging.DEBUG, logging.root)
     else:
         lgdogging.setup()
+        lgdogging.setup(logging.WARNING, logging.getLogger("lh5"))
 
     io.show(
         args.lh5_file,
@@ -170,6 +171,7 @@ Exclude the /data/table1/col1 Table column:
         lgdogging.setup(logging.DEBUG, logging.root)
     else:
         lgdogging.setup()
+        lgdogging.setup(logging.WARNING, logging.getLogger("lh5"))
 
     lh5concat(
         lh5_files=args.lh5_file,
@@ -177,7 +179,7 @@ Exclude the /data/table1/col1 Table column:
         output=args.output,
         include_list=args.include,
         exclude_list=args.exclude,
-        progress=sys.stdout.isatty(),
+        progress=sys.stderr.isatty() and not args.verbose and not args.debug,
     )
 
 
@@ -283,6 +285,7 @@ Include only specific paths:
         lgdogging.setup(logging.DEBUG, logging.root)
     else:
         lgdogging.setup()
+        lgdogging.setup(logging.WARNING, logging.getLogger("lh5"))
 
     # parse length_or_slice: could be an integer or a slice like "10:50"
     length_or_slice: int | slice

--- a/src/lh5/cli.py
+++ b/src/lh5/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import sys
 
 import lgdo
 import lgdo.logging as lgdogging  # eheheh
@@ -176,6 +177,7 @@ Exclude the /data/table1/col1 Table column:
         output=args.output,
         include_list=args.include,
         exclude_list=args.exclude,
+        progress=sys.stdout.isatty(),
     )
 
 

--- a/src/lh5/io/concat.py
+++ b/src/lh5/io/concat.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import fnmatch
 import logging
+from contextlib import nullcontext
 
 from lgdo.types import Array, Scalar, Struct, Table, VectorOfVectors
+from rich import progress as rich_progress
 
 from .iterator import LH5Iterator
 from .store import LH5Store
@@ -148,6 +150,7 @@ def lh5concat(
     *,
     include_list: list | None = None,
     exclude_list: list | None = None,
+    progress: bool = False,
 ) -> None:
     """Concatenate LGDO Arrays, VectorOfVectors and Tables in LH5 files.
 
@@ -161,6 +164,8 @@ def lh5concat(
         patterns for tables to include.
     exclude_list
         patterns for tables to exclude.
+    progress
+        if ``True``, display a progress bar.
     """
 
     if len(lh5_files) < 2:
@@ -178,38 +183,64 @@ def lh5concat(
     lgdos, lgdo_structs = _get_lgdos(lh5_files[0], obj_list)
     first_done = False
     store = LH5Store()
+    n_files = len(lh5_files)
 
-    # loop over lgdo objects
-    for lgdo in lgdos:
-        # iterate over the files
-        for lh5_obj in LH5Iterator(lh5_files, lgdo):
-            data = {lgdo: lh5_obj}
+    prog_ctx = (
+        rich_progress.Progress(
+            rich_progress.SpinnerColumn(),
+            rich_progress.TextColumn("{task.description}"),
+            rich_progress.BarColumn(),
+            rich_progress.TaskProgressColumn(),
+            rich_progress.MofNCompleteColumn(),
+            rich_progress.TimeElapsedColumn(),
+            rich_progress.TimeRemainingColumn(compact=True),
+        )
+        if progress
+        else nullcontext()
+    )
 
-            # remove the nested fields
-            _remove_nested_fields(data, obj_list)
+    with prog_ctx as prog:
+        task = None
+        if prog is not None:
+            total_rows = sum(len(LH5Iterator(lh5_files, name)) for name in lgdos)
+            task = prog.add_task("Concatenating...", total=total_rows)
 
-            if first_done is False:
-                msg = f"creating output file {output}"
-                log.info(msg)
+        # loop over lgdo objects
+        for lgdo in lgdos:
+            if prog is not None:
+                prog.update(task, description=lgdo)
 
-                store.write(
-                    data[lgdo],
-                    lgdo,
-                    output,
-                    wo_mode="overwrite_file"
-                    if (overwrite and not first_done)
-                    else "write_safe",
-                )
-                first_done = True
+            # iterate over files one at a time to track per-file progress
+            for i_file, lh5_file in enumerate(lh5_files):
+                file_tag = f"[{i_file + 1}/{n_files}] {lh5_file}"
 
-            else:
-                msg = f"appending to {output}"
-                log.info(msg)
+                for lh5_obj in LH5Iterator([lh5_file], lgdo):
+                    data = {lgdo: lh5_obj}
 
-                if isinstance(data[lgdo], Table):
-                    _inplace_table_filter(lgdo, data[lgdo], obj_list)
+                    # remove the nested fields
+                    _remove_nested_fields(data, obj_list)
 
-                store.write(data[lgdo], lgdo, output, wo_mode="append")
+                    if first_done is False:
+                        log.info("creating output file %s (%s)", output, file_tag)
+
+                        store.write(
+                            data[lgdo],
+                            lgdo,
+                            output,
+                            wo_mode="overwrite_file" if overwrite else "write_safe",
+                        )
+                        first_done = True
+
+                    else:
+                        log.info("appending to %s (%s)", output, file_tag)
+
+                        if isinstance(data[lgdo], Table):
+                            _inplace_table_filter(lgdo, data[lgdo], obj_list)
+
+                        store.write(data[lgdo], lgdo, output, wo_mode="append")
+
+                    if prog is not None:
+                        prog.advance(task, len(lh5_obj))
 
     if lgdo_structs != {}:
         output_file = store.gimme_file(output, mode="a")

--- a/src/lh5/io/concat.py
+++ b/src/lh5/io/concat.py
@@ -214,6 +214,13 @@ def lh5concat(
             for i_file, lh5_file in enumerate(lh5_files):
                 file_tag = f"[{i_file + 1}/{n_files}] {lh5_file}"
 
+                h5f = store.gimme_file(lh5_file, "r")
+                lgdo_missing = lgdo not in h5f
+                h5f.close()
+                if lgdo_missing:
+                    log.warning("object '%s' not found in %s, skipping", lgdo, lh5_file)
+                    continue
+
                 for lh5_obj in LH5Iterator([lh5_file], lgdo):
                     data = {lgdo: lh5_obj}
 

--- a/src/lh5/io/concat.py
+++ b/src/lh5/io/concat.py
@@ -191,7 +191,7 @@ def lh5concat(
             rich_progress.TextColumn("{task.description}"),
             rich_progress.BarColumn(),
             rich_progress.TaskProgressColumn(),
-            rich_progress.MofNCompleteColumn(),
+            rich_progress.TextColumn("{task.completed:.0f}/{task.total:.0f} rows"),
             rich_progress.TimeElapsedColumn(),
             rich_progress.TimeRemainingColumn(compact=True),
         )
@@ -202,7 +202,14 @@ def lh5concat(
     with prog_ctx as prog:
         task = None
         if prog is not None:
-            total_rows = sum(len(LH5Iterator(lh5_files, name)) for name in lgdos)
+            total_rows = 0
+            for name in lgdos:
+                for f in lh5_files:
+                    h5f = store.gimme_file(f, "r")
+                    present = name in h5f
+                    h5f.close()
+                    if present:
+                        total_rows += len(LH5Iterator([f], name))
             task = prog.add_task("Concatenating...", total=total_rows)
 
         # loop over lgdo objects
@@ -221,6 +228,11 @@ def lh5concat(
                     log.warning("object '%s' not found in %s, skipping", lgdo, lh5_file)
                     continue
 
+                if first_done:
+                    log.info("appending to %s (%s)", output, file_tag)
+                else:
+                    log.info("creating output file %s (%s)", output, file_tag)
+
                 for lh5_obj in LH5Iterator([lh5_file], lgdo):
                     data = {lgdo: lh5_obj}
 
@@ -228,8 +240,6 @@ def lh5concat(
                     _remove_nested_fields(data, obj_list)
 
                     if first_done is False:
-                        log.info("creating output file %s (%s)", output, file_tag)
-
                         store.write(
                             data[lgdo],
                             lgdo,
@@ -239,8 +249,6 @@ def lh5concat(
                         first_done = True
 
                     else:
-                        log.info("appending to %s (%s)", output, file_tag)
-
                         if isinstance(data[lgdo], Table):
                             _inplace_table_filter(lgdo, data[lgdo], obj_list)
 

--- a/tests/lh5/test_concat.py
+++ b/tests/lh5/test_concat.py
@@ -166,6 +166,75 @@ def test_concat(lgnd_test_data, tmptestdir):
         concat.lh5concat(output=outfile, lh5_files=[infile1], overwrite=True)
 
 
+def test_concat_missing_object(tmptestdir):
+    infile1 = f"{tmptestdir}/missing_in1.lh5"
+    infile2 = f"{tmptestdir}/missing_in2.lh5"
+    outfile = f"{tmptestdir}/missing_out.lh5"
+
+    store = lh5.LH5Store()
+
+    # file1 has two tables: a and b
+    store.write(
+        types.Table({"x": types.Array(np.array([1, 2, 3]))}),
+        "a",
+        infile1,
+        wo_mode="overwrite_file",
+    )
+    store.write(
+        types.Table({"y": types.Array(np.array([4, 5, 6]))}),
+        "b",
+        infile1,
+        wo_mode="append",
+    )
+
+    # file2 only has table a (b is absent)
+    store.write(
+        types.Table({"x": types.Array(np.array([7, 8, 9]))}),
+        "a",
+        infile2,
+        wo_mode="overwrite_file",
+    )
+
+    # should not crash; b from file2 is skipped with a WARNING
+    concat.lh5concat(output=outfile, lh5_files=[infile1, infile2], overwrite=True)
+
+    result_a = store.read("a", outfile)
+    assert len(result_a) == 6
+    assert np.array_equal(result_a["x"].nda, np.array([1, 2, 3, 7, 8, 9]))
+
+    result_b = store.read("b", outfile)
+    assert len(result_b) == 3
+    assert np.array_equal(result_b["y"].nda, np.array([4, 5, 6]))
+
+
+def test_concat_progress(tmptestdir):
+    infile1 = f"{tmptestdir}/prog_in1.lh5"
+    infile2 = f"{tmptestdir}/prog_in2.lh5"
+    outfile = f"{tmptestdir}/prog_out.lh5"
+
+    store = lh5.LH5Store()
+    store.write(
+        types.Table({"x": types.Array(np.array([1, 2, 3]))}),
+        "tab",
+        infile1,
+        wo_mode="overwrite_file",
+    )
+    store.write(
+        types.Table({"x": types.Array(np.array([4, 5, 6]))}),
+        "tab",
+        infile2,
+        wo_mode="overwrite_file",
+    )
+
+    concat.lh5concat(
+        output=outfile, lh5_files=[infile1, infile2], overwrite=True, progress=True
+    )
+
+    result = store.read("tab", outfile)
+    assert len(result) == 6
+    assert np.array_equal(result["x"].nda, np.array([1, 2, 3, 4, 5, 6]))
+
+
 def test_concat_empty(tmptestdir):
     infile1 = f"{tmptestdir}/in1.lh5"
     tab1 = types.Table({"a": types.Array(np.array([]))})


### PR DESCRIPTION
## Summary

- Add a `progress: bool = False` parameter to `lh5concat`. When `True`, a `rich` progress bar tracks rows written across all lgdo objects and files. The CLI enables it automatically when stdout is a TTY.
- Restructure the inner loop to iterate input files one at a time (`LH5Iterator([file], lgdo)`) so INFO log messages include the file index and name.
- Fix crash when a file is missing an object that was discovered in the first file: each file is now checked with h5py before the iterator is created, and skipped with a `WARNING` if the object is absent.

## Test plan

- [x] Existing `test_concat` and `test_concat_empty` pass
- [x] Run `lh5concat` interactively and confirm the progress bar appears
- [x] Run `lh5concat` piped to a file and confirm no progress bar output
- [x] Test with a file set where not all files contain every object (reproduces the reported crash)