### PR TITLE
chore: fix typos and bugs in docstrings

### DIFF
--- a/src/lh5/cli.py
+++ b/src/lh5/cli.py
@@ -1,4 +1,4 @@
-"""legend-pydataobj's command line interface utilities."""
+"""legend-lh5io's command line interface utilities."""
 
 from __future__ import annotations
 

--- a/src/lh5/compression/__init__.py
+++ b/src/lh5/compression/__init__.py
@@ -18,9 +18,10 @@ interface for encoding/decoding :class:`~.lgdo.LGDO`\ s.
 
 >>> from lgdo import WaveformTable
 >>> from lh5 import compression
+>>> from lh5.compression import RadwareSigcompress
 >>> wftbl = WaveformTable(...)
->>> enc_wft = compression.encode(wftable, RadwareSigcompress(codec_shift=-23768)
->>> compression.decode(enc_wft) # == wftbl
+>>> enc_wf = compression.encode(wftbl.values, RadwareSigcompress(codec_shift=-23768))
+>>> compression.decode(enc_wf)  # == wftbl.values
 """
 
 from __future__ import annotations

--- a/src/lh5/compression/base.py
+++ b/src/lh5/compression/base.py
@@ -13,7 +13,7 @@ class WaveformCodec:
 
     Note
     ----
-    This is an abstract type. The user must provided a concrete subclass.
+    This is an abstract type. The user must provide a concrete subclass.
     """
 
     @property

--- a/src/lh5/compression/generic.py
+++ b/src/lh5/compression/generic.py
@@ -48,8 +48,8 @@ def decode(
     """Decode encoded LGDOs.
 
     Defines decoding behaviors for each implemented waveform encoding
-    algorithm. Expects to find the codec (and its parameters) the arrays where
-    encoded with among the LGDO attributes.
+    algorithm. The codec (and its parameters) used to encode the arrays must
+    be stored among the LGDO attributes.
 
     Parameters
     ----------

--- a/src/lh5/compression/radware.py
+++ b/src/lh5/compression/radware.py
@@ -26,7 +26,7 @@ class RadwareSigcompress(WaveformCodec):
 
     Examples
     --------
-    >>> from lgdo.compression import RadwareSigcompress
+    >>> from lh5.compression import RadwareSigcompress
     >>> codec = RadwareSigcompress(codec_shift=-32768)
     """
 
@@ -223,7 +223,7 @@ def decode(
     if isinstance(sig_in, tuple):
         s = sig_in[0].shape
         if sig_out is None:
-            # allocate output array with lasd dim as large as the longest
+            # allocate output array with last dim as large as the longest
             # uncompressed wf
             maxs = np.max(_get_hton_u16(sig_in[0], 0))
             sig_out = np.empty((*s[:-1], maxs), dtype=int32)
@@ -295,7 +295,7 @@ def decode(
         # sanity check
         assert np.array_equal(sig_in.decoded_size, siglen)
 
-        # converto to VOV before returning
+        # convert to VOV before returning
         return sig_out.to_vov(np.cumsum(siglen, dtype=uint32))
 
     msg = "unsupported input signal type"
@@ -410,12 +410,8 @@ def _radware_sigcompress_encode(
     shift
         value to be added to `sig_in` before compression.
     siglen
-        array that will hold the lengths of the compressed signals.
-
-    Returns
-    -------
-    length
-        number of bytes in the encoded signal
+        output array; ``siglen[0]`` is set to the number of bytes in the
+        encoded signal.
     """
     mask = _mask
     shift = shift[0]
@@ -576,7 +572,7 @@ def _radware_sigcompress_decode(
     siglen: uint32,
     _mask: NDArray[uint16] = _radware_sigcompress_mask,
 ) -> None:
-    """Deompress a digital signal.
+    """Decompress a digital signal.
 
     After decoding, the signal values are shifted by ``-shift`` to restore the
     original waveform. The dtype of `sig_out` must be large enough to contain it.
@@ -597,11 +593,9 @@ def _radware_sigcompress_decode(
     shift
         the value the original signal(s) was shifted before compression.  The
         value is *subtracted* from samples in `sig_out` right after decoding.
-
-    Returns
-    -------
-    length
-        length of output, decompressed signal.
+    siglen
+        output array; ``siglen[0]`` is set to the length (number of samples)
+        of the decompressed signal.
     """
     mask = _mask
     shift = shift[0]

--- a/src/lh5/compression/varlen.py
+++ b/src/lh5/compression/varlen.py
@@ -151,7 +151,7 @@ def decode(
     | lgdo.ArrayOfEncodedEqualSizedArrays,
     sig_out: NDArray | lgdo.ArrayOfEqualSizedArrays = None,
 ) -> (NDArray, NDArray[uint32]) | lgdo.VectorOfVectors | lgdo.ArrayOfEqualSizedArrays:
-    """Deompress digital signal(s) with a variable-length encoding of its derivative.
+    """Decompress digital signal(s) with a variable-length encoding of its derivative.
 
     Wraps :func:`uleb128_zigzag_diff_array_decode` and adds support for decoding
     LGDOs.
@@ -256,7 +256,7 @@ def decode(
         # sanity check
         assert np.array_equal(sig_in.decoded_size, siglen)
 
-        # converto to VOV before returning
+        # convert to VOV before returning
         return sig_out.to_vov(np.cumsum(siglen, dtype=uint32))
 
     msg = "unsupported input signal type"

--- a/src/lh5/io/__init__.py
+++ b/src/lh5/io/__init__.py
@@ -1,7 +1,8 @@
 """Routines for reading and writing LEGEND Data Objects in HDF5 files.
-Currently the primary on-disk format for LGDO object is LEGEND HDF5 (LH5) files. IO
+
+Currently the primary on-disk format for LGDO objects is LEGEND HDF5 (LH5) files. IO
 is done via the class :class:`.store.LH5Store`. LH5 files can also be
-browsed easily in python like any `HDF5 <https://www.hdfgroup.org>`_ file using
+browsed easily in Python like any `HDF5 <https://www.hdfgroup.org>`_ file using
 `h5py <https://www.h5py.org>`_.
 """
 

--- a/src/lh5/io/_serializers/read/utils.py
+++ b/src/lh5/io/_serializers/read/utils.py
@@ -190,7 +190,7 @@ def read_n_rows(h5o, fname, oname):
 
 
 def read_size_in_bytes(h5o, fname, oname, field_mask=None):
-    """Read number size in LH5 object in memory (in B)"""
+    """Read size of LH5 object in memory (in bytes)."""
     if not h5py.h5a.exists(h5o, b"datatype"):
         msg = "missing 'datatype' attribute"
         raise LH5DecodeError(msg, fname, oname)

--- a/src/lh5/io/concat.py
+++ b/src/lh5/io/concat.py
@@ -57,7 +57,7 @@ def _get_obj_list(
 
 
 def _get_lgdos(file, obj_list):
-    """Get name of LGDO objects."""
+    """Get names of array-like LGDO objects present in the file."""
 
     store = LH5Store()
     h5f0 = store.gimme_file(file)
@@ -113,7 +113,7 @@ def _get_lgdos(file, obj_list):
 
 
 def _inplace_table_filter(name, table, obj_list):
-    """filter objects nested in this LGDO"""
+    """Filter objects nested in this LGDO."""
     skm = fnmatch.filter(obj_list, f"{name}/*")
     kept = {it.removeprefix(name).strip("/").split("/")[0] for it in skm}
 
@@ -159,7 +159,9 @@ def lh5concat(
     lh5_files
         list of input files to concatenate.
     output
-        path to the output file
+        path to the output file.
+    overwrite
+        if ``True``, overwrite the output file if it already exists.
     include_list
         patterns for tables to include.
     exclude_list

--- a/src/lh5/io/core.py
+++ b/src/lh5/io/core.py
@@ -52,7 +52,7 @@ def read(
         actual number of rows read will be returned as one of the return
         values (see below).
     idx
-        For NumPy-style "fancying indexing" for the read to select only
+        For NumPy-style "fancy indexing" for the read to select only
         some rows, e.g. after applying some cuts to particular columns.
         Only selection along the first axis is supported, so tuple
         arguments must be one-tuples.  A 2D array of shape (N, 2) can be.
@@ -274,13 +274,13 @@ def write(
     `compression` attribute.
 
     Note
-    ----------
+    ----
     The `compression` LGDO attribute takes precedence over the default HDF5
     compression settings. The `hdf5_settings` attribute takes precedence
     over `compression`. These attributes are not written to disk.
 
     Note
-    ----------
+    ----
     HDF5 compression is skipped for the `encoded_data.flattened_data`
     dataset of :class:`.VectorOfEncodedVectors` and
     :class:`.ArrayOfEncodedEqualSizedArrays`.
@@ -288,7 +288,7 @@ def write(
     Parameters
     ----------
     obj
-        LH5 object. if object is array-like, writes `n_rows` starting from
+        LH5 object. If object is array-like, writes `n_rows` starting from
         `start_row` in `obj`.
     name
         name of the object in the output HDF5 file.
@@ -311,7 +311,7 @@ def write(
           starting from `write_start`. Note: overwriting with `write_start` =
           end of array is the same as ``append``.
         - ``overwrite_file`` or ``of``: delete file if present prior to
-          writing to it. `write_start` should be 0 (its ignored).
+          writing to it. `write_start` should be 0 (it's ignored).
         - ``append_column`` or ``ac``: append fields/columns from an
           :class:`~.lgdo.struct.Struct` `obj` (and derived types such as
           :class:`~.lgdo.table.Table`) only if there is an existing
@@ -323,15 +323,15 @@ def write(
         row in the output file (if already existing) to start overwriting
         from.
     page_buffer
-        enable paged aggregation with a buffer of this size in bytes
+        enable paged aggregation with a buffer of this size in bytes.
         Only used when creating a new file. Useful when writing a file
         with a large number of small datasets. This is a short-hand for
-        ``(fs_stragety="page", fs_pagesize=[page_buffer])``
+        ``(fs_strategy="page", fs_page_size=page_buffer)``
     **h5py_kwargs
         additional keyword arguments forwarded to
         :meth:`h5py.Group.create_dataset` to specify, for example, an HDF5
         compression filter to be applied before writing non-scalar
-        datasets. **Note: `compression` Ignored if compression is specified
+        datasets. **Note: `compression` ignored if compression is specified
         as an `obj` attribute.**
     """
 

--- a/src/lh5/io/datatype.py
+++ b/src/lh5/io/datatype.py
@@ -27,7 +27,7 @@ _lgdo_datatype_map: dict[str, types.LGDO] = OrderedDict(
         (types.Array, r"^array<\d+>\{.+\}$"),
     ]
 )
-"""Mapping between LGDO types and regular expression defining the corresponding datatype string"""
+"""Mapping between LGDO types and regular expressions defining the corresponding datatype string."""
 
 
 def datatype(expr: str) -> type:

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -111,7 +111,7 @@ class LH5Iterator(Iterator):
 
             LH5Iterator(
                 ["/path1/*.lh5", "/path2/file.lh5", ["/path3/file1.lh5", "/path3/file2.lh5"]],
-                ["ch1/table", ["ch1/table", "ch2/table"], ["ch1/table, "ch2/table, "ch3/table"]]
+                ["ch1/table", ["ch1/table", "ch2/table"], ["ch1/table", "ch2/table", "ch3/table"]]
             )
 
         Parameters
@@ -120,6 +120,8 @@ class LH5Iterator(Iterator):
             file(s) to read from (see above). May include wildcards and environment variables.
         groups
             HDF5 group(s) to read (see above).
+        base_path
+            directory path prepended to all file names.
         entry_list
             list of entry numbers to read. If a nested list is provided,
             expect one top-level list for each file, containing a list of
@@ -143,7 +145,7 @@ class LH5Iterator(Iterator):
             number of entries in tables yielded by iterator. Can be provided as
             a value with a unit of memory; in this case, use the estimated number
             of rows that will yield tables that require the provided memory.
-            Default to 100*MB.
+            Defaults to ``"100*MB"``.
         file_cache
             maximum number of files to keep open at a time
         ds_map
@@ -166,7 +168,7 @@ class LH5Iterator(Iterator):
             groups, or elements in a dataset, raise an Exception.
         h5py_open_mode
             file open mode used when acquiring file handles. ``r`` (default)
-            opens files read-only while ``a`` allow opening files for
+            opens files read-only while ``a`` allows opening files for
             write-appending as well.
         """
 
@@ -510,7 +512,7 @@ class LH5Iterator(Iterator):
         return self.global_entry_list
 
     def read(self, i_entry: int, n_entries: int | None = None) -> Table:
-        "Read the nextlocal chunk of events, starting at entry."
+        """Read a chunk of events starting at global entry `i_entry`."""
         self.lh5_buffer.resize(0)
 
         if n_entries is None:
@@ -844,7 +846,7 @@ class LH5Iterator(Iterator):
 
     @property
     def current_global_entries(self) -> NDArray[int]:
-        """Return list of local file entries in buffer"""
+        """Return list of global file entries in buffer"""
         cur_entries = np.zeros(len(self.lh5_buffer), dtype="int32")
         i_ds = np.searchsorted(self.entry_map, self.current_i_entry, "right")
         ds_start = self._get_ds_cumentries(i_ds - 1)
@@ -1022,8 +1024,8 @@ class LH5Iterator(Iterator):
             fr._select_datasets(i_beg, i_end)
 
     def _generate_workers(self, n_workers: int):
-        """Create n_workers copy of this iterator, dividing the datasets (file/groups)
-        groups between them. These are intended for parallel use"""
+        """Create `n_workers` copies of this iterator, dividing the datasets (file/group pairs)
+        between them. These are intended for parallel use."""
         i_datasets = np.linspace(0, self.n_datasets, n_workers + 1).astype("int")
         # if we have an entry list, get local entries for all files
         if self.local_entry_list is not None:
@@ -1133,7 +1135,7 @@ class LH5Iterator(Iterator):
             with number of processes equal to ``processes``.
         progress_queue:
             :class:`multiprocessing.Queue` object to which progress information will be
-            communicated back go main process. Return mapping with keys:
+            communicated back to main process. Returns a mapping with keys:
             - task_id: the job_id passed to this function
             - total: total number of datasets to be processed
             - completed: number of datasets that have been processed
@@ -1250,7 +1252,7 @@ class LH5Iterator(Iterator):
             to ``executor`` (if provided), or else do not parallelize
         executor:
             :class:`concurrent.futures.Executor` object for managing parallelism.
-            If ``None``, create a :class:`concurrent.futures.rocessPoolExecutor`
+            If ``None``, create a :class:`concurrent.futures.ProcessPoolExecutor`
             with number of processes equal to ``processes``.
         library:
             library to convert the columns to when using a string expression for ``where``.
@@ -1340,10 +1342,10 @@ class LH5Iterator(Iterator):
         --------
         Build a 1D histogram of values in ``col3`` with a string selection::
 
-            h = lh5_it.query(
-                hist.axis.RegularAxis(100, 0, 500, label="col3")
-                where = "(col1 == 0) & (col2 > 100)",
-                keys = "col3"
+            h = lh5_it.hist(
+                hist.axis.Regular(100, 0, 500, label="col3"),
+                where="(col1 == 0) & (col2 > 100)",
+                keys="col3",
             )
 
         Build a 2D histogram with a value axis and string-category axis after
@@ -1353,10 +1355,10 @@ class LH5Iterator(Iterator):
                 ...process data
                 return value, category
 
-            h = lh5_it
-                [hist.axis.RegularAxis(100, 0, 500, label="Value"),
+            h = lh5_it.hist(
+                [hist.axis.Regular(100, 0, 500, label="Value"),
                  hist.axis.StrCategory([], growth=True, label="Category")],
-                 where = get_val,
+                where=get_val,
             )
 
         Parameters
@@ -1388,7 +1390,7 @@ class LH5Iterator(Iterator):
             to ``executor`` (if provided), or else do not parallelize
         executor:
             :class:`concurrent.futures.Executor` object for managing parallelism.
-            If ``None``, create a :class:`concurrent.futures.rocessPoolExecutor`
+            If ``None``, create a :class:`concurrent.futures.ProcessPoolExecutor`
             with number of processes equal to ``processes``.
         progress:
             if ``True`` draw progress bar; can also provide an existing rich ``Progress``
@@ -1435,7 +1437,7 @@ def _identity(val, _):
 
 
 def _append_copy(list, val):
-    "Helper for aggregating tables in query"
+    """Helper for aggregating tables in query"""
     list.append(deepcopy(val))
 
 
@@ -1450,7 +1452,7 @@ def _map_helper(
     *,
     progress_queue: Queue = None,
 ):
-    "Helper for executing int, begin and terminate functions when calling map"
+    """Helper for executing init, begin and terminate functions when calling map"""
     if progress_queue is not None:
         progress_queue.put(
             {
@@ -1525,7 +1527,7 @@ def _map_helper(
 
 @dataclass
 class _table_query:
-    "Helper for when query is called on a string"
+    """Helper for when query is called on a string"""
 
     expr: str
     library: str
@@ -1537,7 +1539,7 @@ class _table_query:
             self.fields = dict.fromkeys(self.fields)
 
     def __call__(self, tab, _):
-        "Evaluate selection and return selected elements"
+        """Evaluate selection and return selected elements"""
         args = {f: a.view_as("ak", with_units=False) for f, a in tab.items()}
         if self.fields is not None:
             for k, v in self.fields.items():
@@ -1565,7 +1567,7 @@ class _table_query:
 
 
 class _hist_filler:
-    "Helper for filling histogram"
+    """Helper for filling histogram"""
 
     def __init__(self, keys):
         if keys is not None:
@@ -1614,13 +1616,15 @@ class MapProgress(Thread):
         update_period: float = 0.1,
     ):
         """
-        tasks:
+        Parameters
+        ----------
+        tasks
             list of descriptions to prepend to progress bars. Can also provide the number of
-            tasks, in which case description will be set to "#i"
-        progress:
+            tasks, in which case description will be set to ``"#i"``.
+        prog
             rich Progress or Console object to add bars to. Use to customize the bar.
-        update_period:
-            frequency in s to update progress bars.
+        update_period
+            frequency in seconds to update progress bars.
         """
         if isinstance(prog, progress.Progress):
             self.progress = prog

--- a/src/lh5/io/settings.py
+++ b/src/lh5/io/settings.py
@@ -4,11 +4,11 @@ from typing import Any
 
 
 def default_hdf5_settings() -> dict[str, Any]:
-    """Returns the HDF5 settings for writing data to disk to the pydataobj defaults.
+    """Returns the HDF5 settings for writing data to disk reset to the package defaults.
 
     Examples
     --------
-    >>> from lgdo import lh5
+    >>> import lh5
     >>> lh5.DEFAULT_HDF5_SETTINGS["compression"] = "lzf"
     >>> lh5.write(data, "data", "file.lh5")  # compressed with LZF
     >>> lh5.DEFAULT_HDF5_SETTINGS = lh5.default_hdf5_settings()
@@ -28,7 +28,7 @@ Modify this global variable before writing data to disk with this package.
 
 Examples
 --------
->>> from lgdo import lh5
+>>> import lh5
 >>> lh5.DEFAULT_HDF5_SETTINGS["compression"] = "lzf"
 >>> lh5.write(data, "data", "file.lh5")  # compressed with LZF
 """

--- a/src/lh5/io/store.py
+++ b/src/lh5/io/store.py
@@ -1,5 +1,5 @@
 """
-This module implements routines from reading and writing LEGEND Data Objects in
+This module implements routines for reading and writing LEGEND Data Objects in
 HDF5 files.
 """
 
@@ -31,9 +31,9 @@ class LH5Store:
 
     Examples
     --------
-    >>> from lgdo import LH5Store
+    >>> from lh5 import LH5Store
     >>> store = LH5Store()
-    >>> obj, _ = store.read("/geds/waveform", "file.lh5")
+    >>> obj = store.read("/geds/waveform", "file.lh5")
     >>> type(obj)
     lgdo.waveformtable.WaveformTable
     """
@@ -101,10 +101,10 @@ class LH5Store:
             mode in which to open file. See :class:`h5py.File` documentation. If
             ``None``, use default provided at construction
         page_buffer
-            enable paged aggregation with a buffer of this size in bytes
+            enable paged aggregation with a buffer of this size in bytes.
             Only used when creating a new file. Useful when writing a file
             with a large number of small datasets. This is a short-hand for
-            ``(fs_stragety="page", fs_pagesize=[page_buffer])``
+            ``(fs_strategy="page", fs_page_size=page_buffer)``
         file_kwargs
             Keyword arguments for :class:`h5py.File`
         """
@@ -304,7 +304,7 @@ class LH5Store:
         return utils.read_n_rows(name, self.gimme_file(lh5_file, "r"))
 
     def read_size_in_bytes(self, name: str, lh5_file: str | Path | h5py.File) -> int:
-        """Look up the size (in B) of the object in memory. Will recursively
-        crawl through all objects in a Struct or Table
+        """Look up the size (in bytes) of the object in memory. Will recursively
+        crawl through all objects in a Struct or Table.
         """
         return utils.read_size_in_bytes(name, self.gimme_file(lh5_file, "r"))

--- a/src/lh5/io/tools.py
+++ b/src/lh5/io/tools.py
@@ -22,7 +22,6 @@ def ls(
     """Return a list of LH5 groups in the input file and group, similar
     to ``ls`` or ``h5ls``. Supports wildcards in group names.
 
-
     Parameters
     ----------
     lh5_file

--- a/src/lh5/io/truncate.py
+++ b/src/lh5/io/truncate.py
@@ -58,11 +58,12 @@ def map_lgdo_arrays(
     include_list: list[str] | None = None,
     exclude_list: list[str] | None = None,
 ) -> LGDO | None:
-    """Map a function acting on awkward arrays contained in the lgdo tree on the tree.
+    """Map a function acting on awkward arrays contained in the LGDO tree onto the tree.
+
     The tree structure itself is not altered (compare to map in functional languages),
     except if branches are excluded (explicitly or because they are not in the
-    include_list passed).
-    Also, attributes are propagated unchanged."""
+    include_list passed). Attributes are propagated unchanged.
+    """
     if not _is_included(name, include_list=include_list, exclude_list=exclude_list):
         msg = f"{name} does not match pattern incl={include_list}, excl={exclude_list}"
         log.debug(msg)
@@ -146,8 +147,10 @@ def map_lgdo_arrays_on_file(
     include_list: list | None = None,
     exclude_list: list | None = None,
 ) -> None:
-    """Run function func on all vectorofvectors and all arrays in the file.
-    1st arg of func is the name of the lgdo, 2nd is the array within.
+    """Run `func` on all VectorOfVectors and all arrays in the file.
+
+    The first argument passed to `func` is the name of the LGDO, the second is
+    the awkward array contained within.
     """
 
     # list of root lgdo names. Actually 2nd level, since / is the real root.

--- a/src/lh5/io/utils.py
+++ b/src/lh5/io/utils.py
@@ -60,8 +60,8 @@ def read_n_rows(name: str, h5f: str | Path | h5py.File) -> int | None:
 
 
 def read_size_in_bytes(name: str, h5f: str | Path | h5py.File) -> int | None:
-    """Look up the size (in B) in an LGDO object in memory. Will crawl
-    recursively through members of a Struct or Table
+    """Look up the size (in bytes) of an LGDO object in memory. Will crawl
+    recursively through members of a Struct or Table.
     """
     if not isinstance(h5f, h5py.File):
         try:

--- a/src/lh5/numba_utils.py
+++ b/src/lh5/numba_utils.py
@@ -11,8 +11,10 @@ log = logging.getLogger(__name__)
 
 
 def getenv_bool(name: str, default: bool = False) -> bool:
-    """Get environment value as a boolean, returning True for 1, t and true
-    (caps-insensitive), and False for any other value and default if undefined.
+    """Get environment variable value as a boolean.
+
+    Returns ``True`` for ``1``, ``t`` and ``true`` (case-insensitive), ``False``
+    for any other value, and `default` if the variable is undefined.
     """
     val = os.getenv(name)
     if not val:
@@ -21,8 +23,8 @@ def getenv_bool(name: str, default: bool = False) -> bool:
 
 
 class NumbaDefaults(MutableMapping):
-    """Bare-bones class to store some Numba default options. Defaults values
-    are set from environment variables
+    """Bare-bones class to store some Numba default options. Default values
+    are set from environment variables.
 
     Examples
     --------
@@ -31,20 +33,20 @@ class NumbaDefaults(MutableMapping):
 
     >>> from numba import guvectorize
     >>> from lh5.numba_utils import numba_defaults_kwargs as nb_kwargs
-    >>> @guvectorize([], "", **nb_kwargs, nopython=True) # def proc(...): ...
+    >>> @guvectorize([], "", **nb_kwargs(nopython=True))  # def proc(...): ...
 
     Customize one argument but still set defaults for the others:
 
-    >>> from lh5.numba_utils import numba_defaults as nb_defaults
-    >>> @guvectorize([], "", **nb_defaults(cache=False) # def proc(...): ...
+    >>> from lh5.numba_utils import numba_defaults_kwargs as nb_kwargs
+    >>> @guvectorize([], "", **nb_kwargs(cache=False))  # def proc(...): ...
 
     Override global options at runtime:
 
     >>> from lh5.numba_utils import numba_defaults
-    >>> # must set options before explicitly importing lgdo modules!
+    >>> # must set options before explicitly importing lh5 modules!
     >>> numba_defaults.cache = False
     >>> numba_defaults.boundscheck = True
-    >>> from lgdo import compression # imports of numbified functions happen here
+    >>> from lh5 import compression  # imports of numba-compiled functions happen here
     >>> compression.encode(...)
     """
 


### PR DESCRIPTION
## Summary

- Fix wrong package names in examples (`lgdo` → `lh5`, `pydataobj` → `legend-lh5io`)
- Fix broken example code (unclosed parentheses, wrong variable/method/class names)
- Fix prose typos (`Deompress`, `converto`, `lasd`, `rocessPoolExecutor`, `caps-insensitive`, etc.)
- Fix wrong or missing parameter entries and numpydoc section formatting
- Fix grammar errors throughout

50 issues fixed across 15 files — all docstring/comment only, no logic changes.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] `make -C docs` builds without warnings