### PR TITLE
fix(iterator): use buffer offset for group_data assignment in multi-group reads

### DIFF
--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -544,16 +544,18 @@ class LH5Iterator(Iterator):
 
             i_local = local_i_entry if local_idx is None else local_idx[local_i_entry]
 
+            buf_start = len(self.lh5_buffer)
+
             if len(self.field_mask) > 0 or not isinstance(self.lh5_buffer, Table):
                 self.lh5_buffer = self.lh5_st.read(
                     self.get_group(i_ds),
                     self.get_file(i_ds),
                     start_row=i_local,
-                    n_rows=n_entries - len(self.lh5_buffer),
+                    n_rows=n_entries - buf_start,
                     idx=local_idx,
                     field_mask=self.field_mask,
                     obj_buf=self.lh5_buffer,
-                    obj_buf_start=len(self.lh5_buffer),
+                    obj_buf_start=buf_start,
                 )
             else:
                 self.lh5_buffer.resize(
@@ -563,7 +565,7 @@ class LH5Iterator(Iterator):
             if self.group_data is not None:
                 data = self.get_group_data(i_ds)
                 for f in data.fields:
-                    self.lh5_buffer[f][i_local:] = data[f]
+                    self.lh5_buffer[f][buf_start:] = data[f]
 
             i_ds += 1
             local_i_entry = 0

--- a/tests/lh5/test_lh5_iterator.py
+++ b/tests/lh5/test_lh5_iterator.py
@@ -12,7 +12,7 @@ from hist import axis
 from lgdo import Array, Table, WaveformTable
 from rich import console, progress
 
-from lh5 import LH5Iterator, MapProgress, read
+from lh5 import LH5Iterator, LH5Store, MapProgress, read
 
 
 @pytest.fixture(scope="module")
@@ -608,6 +608,49 @@ def test_group_data(more_lgnd_files):
         }
         assert all(tb.chan.nda == ec)
         assert all(tb.type.nda == et)
+
+
+def test_group_data_buffer_boundary(more_lgnd_files):
+    # Regression test: when a buffer-fill cycle spans multiple groups, group_data
+    # must be stamped only over the rows that each group contributed, not from
+    # index 0 (which overwrites earlier groups' labels with the last group's value).
+    groups = ["ch1084803/hit", "ch1084804/hit", "ch1121600/hit"]
+    chans = [1084803, 1084804, 1121600]
+
+    # Derive per-group row counts from the actual files so the test stays valid
+    # if the fixture data changes.
+    store = LH5Store()
+    rows_per_group = [store.read_n_rows(g, more_lgnd_files[2][0]) for g in groups]
+
+    # Choose buffer_len to guarantee that at least one buffer spans a group
+    # boundary: any value strictly between min and sum of per-group counts works.
+    buffer_len = min(rows_per_group) + 1
+    assert buffer_len < sum(rows_per_group), (
+        "fixture data too small to exercise multi-group buffer boundary"
+    )
+
+    lh5_it = LH5Iterator(
+        more_lgnd_files[2],
+        groups,
+        field_mask=["timestamp"],
+        buffer_len=buffer_len,
+        group_data={"chan": chans},
+    )
+
+    # Build the expected channel sequence by simulating the buffer-fill order:
+    # datasets are visited as (file0,g0),(file0,g1),...,(file1,g0),... and each
+    # buffer is filled greedily up to buffer_len across however many groups needed.
+    n_files = len(more_lgnd_files[2])
+    flat_chan = chans * n_files  # one entry per dataset in iteration order
+    flat_rows = rows_per_group * n_files
+    sequence = [c for c, n in zip(flat_chan, flat_rows, strict=True) for _ in range(n)]
+
+    expected_chan = [
+        sequence[i : i + buffer_len] for i in range(0, len(sequence), buffer_len)
+    ]
+
+    for tb, ec in zip(lh5_it, expected_chan, strict=True):
+        assert list(tb.chan.nda) == ec
 
 
 def test_group_data_none(more_lgnd_files):


### PR DESCRIPTION
## Summary

- `group_data` fields were stamped into the read buffer starting at `i_local` (the row index within the current HDF5 dataset) instead of `buf_start` (the offset in the output buffer where the new dataset's entries begin).
- For a new dataset `i_local` is always 0, so `lh5_buffer[f][0:]` overwrote the `group_data` of all previously accumulated entries with the current dataset's value.
- This silently mislabeled entries from earlier groups (e.g. detector A) as belonging to a later group (detector B) whenever the read loop spanned a group boundary within a single buffer-fill cycle.
- The bug is invisible with a single group (no boundary to cross) but causes data loss in per-group histogram slices when multiple groups are read together.

## Fix

Introduce `buf_start = len(self.lh5_buffer)` before the read call and use it consistently for `n_rows`, `obj_buf_start`, and the `group_data` slice index.

## Test plan

- [ ] Verify that a 2D histogram filled via `LH5Iterator` with multiple groups and `group_data` shows no spurious gaps when sliced per group
- [ ] Verify that single-group behaviour is unchanged
- [ ] Existing test suite passes