### PR TITLE
Update LH5Iterator.hist

### DIFF
--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -1603,17 +1603,48 @@ class _hist_filler:
             hist.fill(data)
         elif isinstance(data, np.ndarray) and len(data.shape) == 2:
             hist.fill(*data)
-        elif isinstance(data, (pd.DataFrame, Mapping)):
+        elif isinstance(data, pd.DataFrame):
             if self.keys is not None:
-                hist.fill(*[data[k] for k in self.keys])
+                hist.fill(*[data.eval(k) for k in self.keys])
+            else:
+                hist.fill(**data)
+        elif isinstance(data, Mapping):
+            if self.keys is not None:
+                hist.fill(
+                    *[
+                        eval(
+                            k,
+                            {
+                                "np": np,
+                                "numpy": np,
+                                "pd": pd,
+                                "pandas": pd,
+                                "ak": ak,
+                                "awkward": ak,
+                            },
+                            data,
+                        )
+                        for k in self.keys
+                    ]
+                )
             else:
                 hist.fill(**data)
         elif isinstance(data, ak.Array):
-            # TODO: handle nested ak arrays
             if self.keys is not None:
-                hist.fill(*[data[k] for k in self.keys])
+                hist.fill(
+                    *[
+                        ak.ravel(
+                            eval(
+                                k,
+                                {"np": np, "numpy": np, "ak": ak, "awkward": ak},
+                                {f: data[f] for f in data.fields},
+                            )
+                        )
+                        for k in self.keys
+                    ]
+                )
             else:
-                hist.fill(*[data[f] for f in data.fields])
+                hist.fill(*[ak.ravel(data[f]) for f in data.fields])
         elif isinstance(data, Collection):
             hist.fill(*data)
         else:

--- a/tests/lh5/test_lh5_iterator.py
+++ b/tests/lh5/test_lh5_iterator.py
@@ -946,6 +946,7 @@ def test_hist(more_lgnd_files):
     yedges[0] *= 0.99
     yedges[-1] *= 1.01
 
+    # construct hist from query returning LGDOobj
     h_lgdo = lh5_it.hist(
         [axis.Variable(xedges), axis.Variable(yedges)],
         where=query_lgdo,
@@ -960,6 +961,7 @@ def test_hist(more_lgnd_files):
     )
     assert np.all(np.array(h_lgdo_mp) == h_exp)
 
+    # construct hist from query returning pandas DataFrame
     h_pd = lh5_it.hist(
         [axis.Variable(xedges), axis.Variable(yedges)],
         where=query_pd,
@@ -974,6 +976,7 @@ def test_hist(more_lgnd_files):
     )
     assert np.all(np.array(h_pd_mp) == h_exp)
 
+    # construct hist from query returning awkward array
     h_ak = lh5_it.hist(
         [axis.Variable(xedges), axis.Variable(yedges)],
         where=query_ak,
@@ -988,6 +991,7 @@ def test_hist(more_lgnd_files):
     )
     assert np.all(np.array(h_ak_mp) == h_exp)
 
+    # construct hist from query returning numpy array
     h_np = lh5_it.hist(
         [axis.Variable(yedges)],
         where=query_np,
@@ -1002,6 +1006,7 @@ def test_hist(more_lgnd_files):
     )
     assert np.all(np.array(h_np_mp) == np.sum(h_exp, axis=0))
 
+    # construct hist from string query
     h_pd_str = lh5_it.hist(
         [axis.Variable(xedges), axis.Variable(yedges)],
         where="zacEmax_ctc_cal>200",
@@ -1015,6 +1020,21 @@ def test_hist(more_lgnd_files):
         processes=2,
     )
     assert np.all(np.array(h_pd_str_mp) == h_exp)
+
+    # construct hist from string query using expressions for keys
+    h_pd_expr = lh5_it.hist(
+        [axis.Variable(xedges), axis.Variable(yedges)],
+        where="zacEmax_ctc_cal>200",
+        keys=[f"timestamp + {xedges[1]}", f"zacEmax_ctc_cal + {yedges[1]}"],
+    )
+    assert np.all(np.array(h_pd_expr)[2:-1, 2:-1] == h_exp[1:-2, 1:-2])
+    h_pd_expr_mp = lh5_it.hist(
+        [axis.Variable(xedges), axis.Variable(yedges)],
+        where="zacEmax_ctc_cal>200",
+        keys=[f"timestamp + {xedges[1]}", f"zacEmax_ctc_cal + {yedges[1]}"],
+        processes=2,
+    )
+    assert np.all(np.array(h_pd_expr_mp)[2:-1, 2:-1] == h_exp[1:-2, 1:-2])
 
 
 def test_progress_bar(more_lgnd_files):


### PR DESCRIPTION
When interpreting key values, use `eval`. This:
- Handles nested keys
- Allows use of expressions to combine multiple table columns

When working with awkward, call ravel on results; this enables filling of histograms with values in ragged arrays.