### PR TITLE
Compact file-space strategy by default, target-size chunking, opt-in page-buffered reads

### DIFF
--- a/src/lh5/io/_serializers/write/array.py
+++ b/src/lh5/io/_serializers/write/array.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 
 import h5py
 import numpy as np
@@ -67,6 +68,18 @@ def _h5_write_array(
         # we'd like to pass a list too in some situations
         if "chunks" in h5py_kwargs and isinstance(h5py_kwargs["chunks"], list):
             h5py_kwargs["chunks"] = tuple(h5py_kwargs["chunks"])
+
+        # translate the "chunk_nbytes" byte target into an explicit chunk
+        # shape unless the user provided one: h5py auto-chunking would
+        # otherwise freeze the chunk shape from this first (possibly tiny)
+        # buffered write for the lifetime of the dataset
+        chunk_nbytes = h5py_kwargs.pop("chunk_nbytes", None)
+        if chunk_nbytes is not None and "chunks" not in h5py_kwargs:
+            row_nbytes = nda.dtype.itemsize * math.prod(nda.shape[1:])
+            h5py_kwargs["chunks"] = (
+                max(1, settings.parse_datasize(chunk_nbytes) // row_nbytes),
+                *nda.shape[1:],
+            )
 
         # create HDF5 dataset
         ds = group.create_dataset(name, data=nda, **h5py_kwargs)

--- a/src/lh5/io/core.py
+++ b/src/lh5/io/core.py
@@ -371,7 +371,9 @@ def write(
         datasets. **Note: `compression` ignored if compression is specified
         as an `obj` attribute.**
     """
-    if page_buffer:
+    page_buffer = settings.parse_datasize(page_buffer or 0)
+    fs_page_size = settings.parse_datasize(fs_page_size or 0)
+    if page_buffer > 0:
         msg = (
             "the 'page_buffer' argument of write() is deprecated and sets the "
             "file-space *page size*; use fs_page_size instead"
@@ -380,7 +382,7 @@ def write(
         fs_page_size = fs_page_size or page_buffer
 
     if (
-        fs_page_size
+        fs_page_size > 0
         and isinstance(lh5_file, str)
         and not Path(lh5_file).is_file()
         and wo_mode in ("w", "write_safe", "of", "overwrite_file")
@@ -388,7 +390,7 @@ def write(
         h5py_kwargs.update(
             {
                 "fs_strategy": "page",
-                "fs_page_size": settings.parse_datasize(fs_page_size),
+                "fs_page_size": fs_page_size,
             }
         )
     return _serializers._h5_write_lgdo(

--- a/src/lh5/io/core.py
+++ b/src/lh5/io/core.py
@@ -8,13 +8,14 @@ from collections.abc import Mapping, Sequence
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
+from warnings import warn
 
 import h5py
 import numpy as np
 from lgdo import types
 from numpy.typing import ArrayLike
 
-from . import _serializers
+from . import _serializers, settings
 from .exceptions import LH5DecodeError
 from .utils import read_n_rows
 
@@ -33,6 +34,7 @@ def read(
     obj_buf_start: int = 0,
     decompress: bool = True,
     locking: bool = False,
+    page_buffer: int | str | None = None,
 ) -> types.LGDO | tuple[types.LGDO, int]:
     """Read LH5 object data from a file.
 
@@ -95,6 +97,13 @@ def read(
         built-in filters, which is always decompressed upstream by HDF5.
     locking
         Lock HDF5 file while reading
+    page_buffer
+        buffer size in bytes (or a string like ``"16MiB"``) for HDF5
+        page-buffered reads. Effective only for files written with the
+        paged file-space strategy (see `fs_page_size` in :func:`.write`);
+        other files are silently opened without a buffer. ``None`` uses the
+        :obj:`.settings.DEFAULT_PAGE_BUFFER` (settable via the
+        ``LH5_PAGE_BUFFER`` environment variable); ``0`` disables.
 
     Returns
     -------
@@ -111,8 +120,29 @@ def read(
         except KeyError as oe:
             raise LH5DecodeError(oe, lh5_file, name) from oe
     elif isinstance(lh5_file, (str, Path)):
+        if page_buffer is None:
+            page_buffer = settings.DEFAULT_PAGE_BUFFER
+        page_buffer = settings.parse_datasize(page_buffer)
         try:
-            lh5_file = h5py.File(str(Path(lh5_file)), mode="r", locking=locking)
+            if page_buffer > 0:
+                # page buffering requires the paged file-space strategy; fall
+                # back to a plain open for other files (handled below)
+                try:
+                    lh5_file = h5py.File(
+                        str(Path(lh5_file)),
+                        mode="r",
+                        locking=locking,
+                        page_buf_size=page_buffer,
+                    )
+                except OSError:
+                    log.debug(
+                        "page-buffered open of %s failed (not a paged file?), "
+                        "retrying without page buffer",
+                        lh5_file,
+                    )
+                    lh5_file = h5py.File(str(Path(lh5_file)), mode="r", locking=locking)
+            else:
+                lh5_file = h5py.File(str(Path(lh5_file)), mode="r", locking=locking)
         except (OSError, FileExistsError) as oe:
             raise LH5DecodeError(oe, lh5_file) from oe
 
@@ -196,6 +226,8 @@ def read(
                 obj_buf=obj_buf,
                 obj_buf_start=obj_buf_start_i,
                 decompress=decompress,
+                locking=locking,
+                page_buffer=page_buffer,
             )
 
             if obj_buf is None or (len(obj_buf) - obj_buf_start) >= n_rows:
@@ -245,6 +277,7 @@ def write(
     wo_mode: str = "append",
     write_start: int = 0,
     page_buffer: int = 0,
+    fs_page_size: int | str = 0,
     **h5py_kwargs,
 ) -> None:
     """Write an LGDO into an LH5 file.
@@ -323,10 +356,14 @@ def write(
         row in the output file (if already existing) to start overwriting
         from.
     page_buffer
-        enable paged aggregation with a buffer of this size in bytes.
-        Only used when creating a new file. Useful when writing a file
-        with a large number of small datasets. This is a short-hand for
-        ``(fs_strategy="page", fs_page_size=page_buffer)``
+        deprecated alias for `fs_page_size`.
+    fs_page_size
+        opt in to HDF5's *paged aggregation* file-space strategy with this
+        page size in bytes (or a string like ``"1MiB"``), when creating a
+        new file. Paged files support page-buffered reads (see
+        :func:`.read`); pick a page size at the scale of the dataset chunks
+        so page-alignment padding stays small. By default files are created
+        with the standard (FSM) strategy, which packs allocations tightly.
     **h5py_kwargs
         additional keyword arguments forwarded to
         :meth:`h5py.Group.create_dataset` to specify, for example, an HDF5
@@ -334,16 +371,24 @@ def write(
         datasets. **Note: `compression` ignored if compression is specified
         as an `obj` attribute.**
     """
+    if page_buffer:
+        msg = (
+            "the 'page_buffer' argument of write() is deprecated and sets the "
+            "file-space *page size*; use fs_page_size instead"
+        )
+        warn(msg, DeprecationWarning, stacklevel=2)
+        fs_page_size = fs_page_size or page_buffer
 
     if (
-        isinstance(lh5_file, str)
+        fs_page_size
+        and isinstance(lh5_file, str)
         and not Path(lh5_file).is_file()
         and wo_mode in ("w", "write_safe", "of", "overwrite_file")
     ):
         h5py_kwargs.update(
             {
                 "fs_strategy": "page",
-                "fs_page_size": page_buffer,
+                "fs_page_size": settings.parse_datasize(fs_page_size),
             }
         )
     return _serializers._h5_write_lgdo(

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -87,6 +87,7 @@ class LH5Iterator(Iterator):
         friend_suffix: str = "",
         safe_mode: bool = True,
         h5py_open_mode: str = "r",
+        page_buffer: int | str | None = None,
     ) -> None:
         """
         Constructor for LH5Iterator. Must provide a file or collection of
@@ -170,6 +171,12 @@ class LH5Iterator(Iterator):
             file open mode used when acquiring file handles. ``r`` (default)
             opens files read-only while ``a`` allows opening files for
             write-appending as well.
+        page_buffer
+            page-buffer size in bytes (or a string like ``"16MiB"``) used
+            when opening files for reading; effective only for files
+            written with the paged file-space strategy. ``None`` uses
+            :obj:`.settings.DEFAULT_PAGE_BUFFER` (settable via the
+            ``LH5_PAGE_BUFFER`` environment variable).
         """
 
         if h5py_open_mode == "read":
@@ -181,7 +188,10 @@ class LH5Iterator(Iterator):
             raise ValueError(msg)
 
         self.lh5_st = LH5Store(
-            base_path=base_path, keep_open=file_cache, default_mode=h5py_open_mode
+            base_path=base_path,
+            keep_open=file_cache,
+            default_mode=h5py_open_mode,
+            page_buffer=page_buffer,
         )
 
         # convert lh5_files into a nested list
@@ -960,7 +970,9 @@ class LH5Iterator(Iterator):
         for k, v in self.__dict__.items():
             if k == "lh5_st":
                 result.lh5_st = LH5Store(
-                    base_path=self.lh5_st.base_path, keep_open=self.lh5_st.keep_open
+                    base_path=self.lh5_st.base_path,
+                    keep_open=self.lh5_st.keep_open,
+                    page_buffer=self.lh5_st.page_buffer,
                 )
             else:
                 setattr(result, k, deepcopy(v, memo))
@@ -973,6 +985,7 @@ class LH5Iterator(Iterator):
             lh5_st={
                 "base_path": self.lh5_st.base_path,
                 "keep_open": self.lh5_st.keep_open,
+                "page_buffer": self.lh5_st.page_buffer,
             },
             lh5_buffer=None,
         )

--- a/src/lh5/io/settings.py
+++ b/src/lh5/io/settings.py
@@ -1,6 +1,39 @@
 from __future__ import annotations
 
+import os
 from typing import Any
+
+_SIZE_SUFFIXES = {
+    "b": 1,
+    "kb": 10**3,
+    "mb": 10**6,
+    "gb": 10**9,
+    "kib": 2**10,
+    "mib": 2**20,
+    "gib": 2**30,
+}
+
+
+def parse_datasize(size: str | int) -> int:
+    """Parse a data size such as ``"16MiB"``, ``"4096"`` or ``16`` into bytes."""
+    if isinstance(size, int):
+        return size
+    s = str(size).strip().lower()
+    for suffix, mult in sorted(_SIZE_SUFFIXES.items(), key=lambda kv: -len(kv[0])):
+        if s.endswith(suffix):
+            return int(float(s[: -len(suffix)]) * mult)
+    return int(float(s))
+
+
+DEFAULT_PAGE_BUFFER: int = parse_datasize(os.getenv("LH5_PAGE_BUFFER", "0"))
+"""Default page-buffer size (bytes) for reading paged LH5 files.
+
+Initialised from the ``LH5_PAGE_BUFFER`` environment variable (binary and
+decimal suffixes accepted, e.g. ``16MiB``), so page-buffered reads can be
+enabled fleet-wide without touching call sites. ``0`` disables page
+buffering. Only files written with the paged file-space strategy can use a
+page buffer; plain files fall back to an unbuffered open.
+"""
 
 
 def default_hdf5_settings() -> dict[str, Any]:
@@ -18,6 +51,11 @@ def default_hdf5_settings() -> dict[str, Any]:
     return {
         "shuffle": True,
         "compression": "gzip",
+        # target chunk size in bytes; translated per dataset into an h5py
+        # "chunks" tuple when the user provides no explicit chunking. Without
+        # it, h5py auto-chunking freezes the chunk shape from the first
+        # (possibly tiny) buffered write.
+        "chunk_nbytes": 256 * 1024,
     }
 
 

--- a/src/lh5/io/store.py
+++ b/src/lh5/io/store.py
@@ -138,6 +138,7 @@ class LH5Store:
         if mode is None:
             mode = self.default_mode
 
+        fs_page_size = settings.parse_datasize(fs_page_size or 0)
         if mode == "r":
             lh5_file = utils.expand_path(lh5_file, base_path=self.base_path)
             file_kwargs["locking"] = self.locking
@@ -145,14 +146,14 @@ class LH5Store:
             pb = settings.parse_datasize(pb)
             if pb > 0:
                 file_kwargs["page_buf_size"] = pb
-        elif page_buffer:
+        elif page_buffer is not None and settings.parse_datasize(page_buffer) > 0:
             msg = (
                 "passing 'page_buffer' for a file opened in a write mode is "
                 "deprecated and sets the file-space *page size*; use "
                 "fs_page_size instead"
             )
             warn(msg, DeprecationWarning, stacklevel=2)
-            fs_page_size = fs_page_size or page_buffer
+            fs_page_size = fs_page_size or settings.parse_datasize(page_buffer)
 
         if lh5_file in self.files:
             self.files.move_to_end(lh5_file)
@@ -179,11 +180,11 @@ class LH5Store:
         if mode != "r" and file_exists:
             log.debug(f"opening existing file {full_path} in mode '{mode}'")
 
-        if mode == "w" and fs_page_size:
+        if mode == "w" and fs_page_size > 0:
             file_kwargs.update(
                 {
                     "fs_strategy": "page",
-                    "fs_page_size": settings.parse_datasize(fs_page_size),
+                    "fs_page_size": fs_page_size,
                 }
             )
         try:

--- a/src/lh5/io/store.py
+++ b/src/lh5/io/store.py
@@ -12,12 +12,13 @@ from collections.abc import Mapping, Sequence
 from inspect import signature
 from pathlib import Path
 from typing import Any
+from warnings import warn
 
 import h5py
 from lgdo import types
 from numpy.typing import ArrayLike
 
-from . import _serializers, utils
+from . import _serializers, settings, utils
 from .core import read
 from .exceptions import LH5DecodeError
 
@@ -44,6 +45,7 @@ class LH5Store:
         keep_open: bool = False,
         locking: bool = False,
         default_mode: str = "r",
+        page_buffer: int | str | None = None,
     ) -> None:
         """
         Parameters
@@ -60,11 +62,23 @@ class LH5Store:
             default mode in which to open files with this ``LH5Store``. See
             :class:`h5py.File` documentation. If default_mode is ``"r"``, use
             ``"a"`` when calling `LH5Store.write`.
+        page_buffer
+            default page-buffer size in bytes (or a string like ``"16MiB"``)
+            used when this store opens files for reading. Effective only for
+            files written with the paged file-space strategy; other files
+            are silently opened without a buffer. ``None`` uses
+            :obj:`.settings.DEFAULT_PAGE_BUFFER` (settable via the
+            ``LH5_PAGE_BUFFER`` environment variable). Note that the store
+            caches open files by path, so the first open of a file decides
+            its buffering for the lifetime of the cache entry.
         """
         base_path = str(Path(base_path)) if base_path != "" else ""
         self.base_path = "" if base_path == "" else utils.expand_path(base_path)
         self.keep_open = keep_open
         self.locking = locking
+        if page_buffer is None:
+            page_buffer = settings.DEFAULT_PAGE_BUFFER
+        self.page_buffer = settings.parse_datasize(page_buffer)
         self.files = OrderedDict()
 
         if default_mode == "read":
@@ -88,7 +102,8 @@ class LH5Store:
         self,
         lh5_file: str | Path | h5py.File,
         mode: str = None,
-        page_buffer: int = 0,
+        page_buffer: int | str | None = None,
+        fs_page_size: int | str = 0,
         **file_kwargs,
     ) -> h5py.File:
         """Returns a :mod:`h5py` file object from the store or creates a new one.
@@ -101,10 +116,17 @@ class LH5Store:
             mode in which to open file. See :class:`h5py.File` documentation. If
             ``None``, use default provided at construction
         page_buffer
-            enable paged aggregation with a buffer of this size in bytes.
-            Only used when creating a new file. Useful when writing a file
-            with a large number of small datasets. This is a short-hand for
-            ``(fs_strategy="page", fs_page_size=page_buffer)``
+            page-buffer size in bytes (or a string like ``"16MiB"``) used
+            when opening a file for reading; effective only for files
+            written with the paged file-space strategy, other files fall
+            back to an unbuffered open. ``None`` uses the store default.
+            When passed for a file opened in a *write* mode, it is a
+            deprecated alias for `fs_page_size`.
+        fs_page_size
+            opt in to HDF5's paged-aggregation file-space strategy with this
+            page size in bytes (or a string like ``"1MiB"``) when creating a
+            new file. By default files are created with the standard (FSM)
+            strategy.
         file_kwargs
             Keyword arguments for :class:`h5py.File`
         """
@@ -119,6 +141,18 @@ class LH5Store:
         if mode == "r":
             lh5_file = utils.expand_path(lh5_file, base_path=self.base_path)
             file_kwargs["locking"] = self.locking
+            pb = self.page_buffer if page_buffer is None else page_buffer
+            pb = settings.parse_datasize(pb)
+            if pb > 0:
+                file_kwargs["page_buf_size"] = pb
+        elif page_buffer:
+            msg = (
+                "passing 'page_buffer' for a file opened in a write mode is "
+                "deprecated and sets the file-space *page size*; use "
+                "fs_page_size instead"
+            )
+            warn(msg, DeprecationWarning, stacklevel=2)
+            fs_page_size = fs_page_size or page_buffer
 
         if lh5_file in self.files:
             self.files.move_to_end(lh5_file)
@@ -145,15 +179,28 @@ class LH5Store:
         if mode != "r" and file_exists:
             log.debug(f"opening existing file {full_path} in mode '{mode}'")
 
-        if mode == "w":
+        if mode == "w" and fs_page_size:
             file_kwargs.update(
                 {
                     "fs_strategy": "page",
-                    "fs_page_size": page_buffer,
+                    "fs_page_size": settings.parse_datasize(fs_page_size),
                 }
             )
         try:
-            h5f = h5py.File(full_path, mode, **file_kwargs)
+            try:
+                h5f = h5py.File(full_path, mode, **file_kwargs)
+            except OSError:
+                # page buffering requires the paged file-space strategy;
+                # fall back to a plain open for other files
+                if "page_buf_size" not in file_kwargs:
+                    raise
+                log.debug(
+                    "page-buffered open of %s failed (not a paged file?), "
+                    "retrying without page buffer",
+                    full_path,
+                )
+                file_kwargs.pop("page_buf_size")
+                h5f = h5py.File(full_path, mode, **file_kwargs)
         except (OSError, FileExistsError) as oe:
             raise LH5DecodeError(oe, full_path) from oe
 
@@ -246,6 +293,7 @@ class LH5Store:
         wo_mode: str = None,
         write_start: int = 0,
         page_buffer: int = 0,
+        fs_page_size: int | str = 0,
         **h5py_kwargs,
     ) -> None:
         """Write an LGDO into an LH5 file.
@@ -286,7 +334,11 @@ class LH5Store:
             obj,
             name,
             self.gimme_file(
-                lh5_file, mode=mode, page_buffer=page_buffer, **file_kwargs
+                lh5_file,
+                mode=mode,
+                page_buffer=page_buffer or None,
+                fs_page_size=fs_page_size,
+                **file_kwargs,
             ),
             group=group,
             start_row=start_row,

--- a/tests/lh5/test_file_layout.py
+++ b/tests/lh5/test_file_layout.py
@@ -8,6 +8,8 @@ reads accept a ``page_buffer``, falling back gracefully on non-paged files.
 
 from __future__ import annotations
 
+import warnings
+
 import h5py
 import numpy as np
 import pytest
@@ -54,6 +56,27 @@ def test_write_page_buffer_alias_warns_and_pages(tmptestdir):
         lh5.write(_make_table(), "tbl", out, wo_mode="overwrite_file", page_buffer=4096)
     strategy, _, _ = _strategy(out)
     assert strategy == h5py.h5f.FSPACE_STRATEGY_PAGE
+
+
+def test_write_string_zero_sizes_stay_fsm(tmptestdir):
+    # "0" is truthy as a string: must still mean "disabled" — no paged
+    # strategy and no deprecation warning
+    for i, kwargs in enumerate([{"fs_page_size": "0"}, {"page_buffer": "0"}]):
+        out = f"{tmptestdir}/zero_str_{i}.lh5"
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            lh5.write(_make_table(), "tbl", out, wo_mode="overwrite_file", **kwargs)
+        strategy, _, _ = _strategy(out)
+        assert strategy == h5py.h5f.FSPACE_STRATEGY_FSM_AGGR
+
+        out = f"{tmptestdir}/zero_str_store_{i}.lh5"
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            lh5.LH5Store().write(
+                _make_table(), "tbl", out, wo_mode="overwrite_file", **kwargs
+            )
+        strategy, _, _ = _strategy(out)
+        assert strategy == h5py.h5f.FSPACE_STRATEGY_FSM_AGGR
 
 
 def test_store_write_defaults_to_fsm(tmptestdir):

--- a/tests/lh5/test_file_layout.py
+++ b/tests/lh5/test_file_layout.py
@@ -1,0 +1,149 @@
+"""Tests for the file-space strategy, chunk policy and page-buffered reads.
+
+Covers the three layout changes: files default to the compact (FSM) strategy
+with paged aggregation as an explicit opt-in via ``fs_page_size``; the
+``chunk_nbytes`` byte target replaces h5py first-write auto-chunking; and
+reads accept a ``page_buffer``, falling back gracefully on non-paged files.
+"""
+
+from __future__ import annotations
+
+import h5py
+import numpy as np
+import pytest
+from lgdo import types
+
+import lh5
+from lh5.io import settings
+
+
+def _strategy(path):
+    with h5py.File(path) as f:
+        return f.id.get_create_plist().get_file_space_strategy()
+
+
+def _make_table(n=1000):
+    return types.Table(
+        size=n,
+        col_dict={
+            "col1": types.Array(np.arange(n, dtype="float64")),
+            "col2": types.Array(np.random.default_rng(1).random(n, dtype="float32")),
+        },
+    )
+
+
+def test_write_defaults_to_fsm_strategy(tmptestdir):
+    out = f"{tmptestdir}/fsm_default.lh5"
+    lh5.write(_make_table(), "tbl", out, wo_mode="overwrite_file")
+    strategy, _, _ = _strategy(out)
+    assert strategy == h5py.h5f.FSPACE_STRATEGY_FSM_AGGR
+
+
+def test_write_fs_page_size_opts_into_paged(tmptestdir):
+    out = f"{tmptestdir}/paged.lh5"
+    lh5.write(_make_table(), "tbl", out, wo_mode="overwrite_file", fs_page_size="64KiB")
+    strategy, _, _ = _strategy(out)
+    assert strategy == h5py.h5f.FSPACE_STRATEGY_PAGE
+    with h5py.File(out) as f:
+        assert f.id.get_create_plist().get_file_space_page_size() == 64 * 1024
+
+
+def test_write_page_buffer_alias_warns_and_pages(tmptestdir):
+    out = f"{tmptestdir}/paged_legacy.lh5"
+    with pytest.warns(DeprecationWarning, match="fs_page_size"):
+        lh5.write(_make_table(), "tbl", out, wo_mode="overwrite_file", page_buffer=4096)
+    strategy, _, _ = _strategy(out)
+    assert strategy == h5py.h5f.FSPACE_STRATEGY_PAGE
+
+
+def test_store_write_defaults_to_fsm(tmptestdir):
+    out = f"{tmptestdir}/store_fsm.lh5"
+    lh5.LH5Store().write(_make_table(), "tbl", out, wo_mode="overwrite_file")
+    strategy, _, _ = _strategy(out)
+    assert strategy == h5py.h5f.FSPACE_STRATEGY_FSM_AGGR
+
+
+def test_default_chunking_hits_byte_target(tmptestdir):
+    out = f"{tmptestdir}/chunks.lh5"
+    # write in two small appends: chunk shape must NOT freeze at 100 rows
+    tbl = _make_table(100)
+    lh5.write(tbl, "tbl", out, wo_mode="overwrite_file")
+    lh5.write(tbl, "tbl", out, wo_mode="append")
+    target = settings.DEFAULT_HDF5_SETTINGS["chunk_nbytes"]
+    with h5py.File(out) as f:
+        d = f["tbl/col1"]  # float64
+        assert d.chunks == (target // 8,)
+        d = f["tbl/col2"]  # float32
+        assert d.chunks == (target // 4,)
+
+
+def test_explicit_chunks_override_byte_target(tmptestdir):
+    out = f"{tmptestdir}/chunks_explicit.lh5"
+    lh5.write(_make_table(), "tbl", out, wo_mode="overwrite_file", chunks=(50,))
+    with h5py.File(out) as f:
+        assert f["tbl/col1"].chunks == (50,)
+
+
+def test_chunking_2d_rows(tmptestdir):
+    out = f"{tmptestdir}/chunks2d.lh5"
+    aoesa = types.ArrayOfEqualSizedArrays(nda=np.zeros((100, 256), dtype="float32"))
+    lh5.write(aoesa, "wfs", out, wo_mode="overwrite_file")
+    target = settings.DEFAULT_HDF5_SETTINGS["chunk_nbytes"]
+    with h5py.File(out) as f:
+        rows = target // (256 * 4)
+        assert f["wfs"].chunks == (rows, 256)
+
+
+def test_read_with_page_buffer_on_paged_file(tmptestdir):
+    out = f"{tmptestdir}/paged_read.lh5"
+    tbl = _make_table()
+    lh5.write(tbl, "tbl", out, wo_mode="overwrite_file", fs_page_size="64KiB")
+    back = lh5.read("tbl", out, page_buffer="1MiB")
+    assert np.array_equal(back["col1"].nda, tbl["col1"].nda)
+
+
+def test_read_with_page_buffer_falls_back_on_fsm_file(tmptestdir):
+    out = f"{tmptestdir}/fsm_read.lh5"
+    tbl = _make_table()
+    lh5.write(tbl, "tbl", out, wo_mode="overwrite_file")
+    # non-paged file: must silently fall back to an unbuffered open
+    back = lh5.read("tbl", out, page_buffer="1MiB")
+    assert np.array_equal(back["col2"].nda, tbl["col2"].nda)
+
+
+def test_store_read_page_buffer(tmptestdir):
+    out = f"{tmptestdir}/store_paged_read.lh5"
+    tbl = _make_table()
+    lh5.write(tbl, "tbl", out, wo_mode="overwrite_file", fs_page_size="64KiB")
+    store = lh5.LH5Store(page_buffer="1MiB")
+    back = store.read("tbl", out)
+    assert len(back) == 1000
+    assert np.array_equal(back["col1"].nda, tbl["col1"].nda)
+
+
+def test_iterator_page_buffer_passthrough(tmptestdir):
+    out = f"{tmptestdir}/it_paged.lh5"
+    tbl = _make_table()
+    lh5.write(tbl, "tbl", out, wo_mode="overwrite_file", fs_page_size="64KiB")
+    it = lh5.LH5Iterator(out, "tbl", buffer_len=300, page_buffer="1MiB")
+    assert it.lh5_st.page_buffer == 2**20
+    n = sum(len(chunk) for chunk in it)
+    assert n == 1000
+
+
+def test_env_default_page_buffer(tmptestdir, monkeypatch):
+    monkeypatch.setattr(settings, "DEFAULT_PAGE_BUFFER", 2**20)
+    out = f"{tmptestdir}/env_paged.lh5"
+    tbl = _make_table()
+    lh5.write(tbl, "tbl", out, wo_mode="overwrite_file", fs_page_size="64KiB")
+    back = lh5.read("tbl", out)  # no explicit page_buffer: uses default
+    assert np.array_equal(back["col1"].nda, tbl["col1"].nda)
+    assert lh5.LH5Store().page_buffer == 2**20
+
+
+@pytest.mark.parametrize(
+    ("size", "nbytes"),
+    [("16MiB", 16 * 2**20), ("4kb", 4000), ("1.5GiB", int(1.5 * 2**30)), (512, 512)],
+)
+def test_parse_datasize(size, nbytes):
+    assert settings.parse_datasize(size) == nbytes


### PR DESCRIPTION
## Motivation

Profiling LEGEND production files (prod-blind/ref v3.3.0, p16) with `h5stat` showed a large fraction of every tier file is HDF5 *page-alignment padding* from the paged file-space strategy this package applies to every new file (4 KiB pages), compounded by tiny chunk sizes frozen by h5py auto-chunking:

| file | size | data | chunk metadata | page padding |
|---|---|---|---|---|
| raw cal (3.9 GB) | 3.94 GB | 3.42 GB | 22 MB | **501 MB (12.7%)** |
| psp cal | 531 MB | 364 MB | 20 MB | **147 MB (27.6%)** |

The 6.4 KB chunks (~500k per file) come from dataset creation with `maxshape=(None, ...)`: h5py auto-chunking sizes the chunks from the first buffered write (~800 rows in production) and they stay that size for the file's lifetime. Meanwhile, nothing in the LEGEND read stack ever enables page-buffered reads — the one feature the paged layout exists to support — so the padding buys nothing today.

## Changes

1. **New files default to HDF5's standard (FSM) file-space strategy.** Paged aggregation becomes an explicit opt-in via a new `fs_page_size=` argument on `write()` / `LH5Store.write()` / `gimme_file()` (accepts `"1MiB"`-style strings). The old `page_buffer` write argument — which actually set the page *size* — remains as a deprecated alias with a `DeprecationWarning`.

2. **`DEFAULT_HDF5_SETTINGS` gains `chunk_nbytes` (256 KiB target).** Translated per dataset into an explicit `chunks` tuple (rows = target / row bytes; handles 2D array rows) unless the caller supplies chunks via kwargs, `hdf5_settings`, or `compression` attributes — existing precedence preserved. This ends the frozen-first-buffer chunking.

3. **Read-side page-buffer support (opt-in).** `read()`/`read_as()` accept `page_buffer=`; `LH5Store` takes it as a constructor default (so `LH5Iterator`'s early `read_n_rows` opens are buffered too, and downstream consumers inherit it with no changes); it survives iterator pickling/deepcopy; non-paged files silently fall back to an unbuffered open, so it is safe on mixed archives; `LH5_PAGE_BUFFER` (e.g. `16MiB`) sets a fleet-wide default. The multi-file recursion in `read()` now also forwards `locking` (previously dropped).

## Measurements behind the defaults

- FSM repack of the 3.9 GB raw file: **-500 MB (12.7%)**, datasets bit-identical, 12 min wall / ~9 s CPU (pure I/O, parallelizes per file). Migration for existing files, no reprocessing: `h5repack -S FSM_AGGR -l CHUNK=... src dst && h5diff -q src dst && mv dst src`.
- Page-buffered reads on a paged production raw file (cold NFS, 16 MiB buffer): open 292 → 72 ms; full metadata walk (6289 objects) 184 → 163 s; sequential 37 MB column 5.7 → 5.1 s; 300 random event reads 12.7 → 11.1 s.

## Testing

- 16 new tests (`tests/lh5/test_file_layout.py`): strategy default/opt-in/deprecation, chunk byte-target (append-mode and 2D), explicit-chunks override, buffered reads on paged and non-paged files, store/iterator pass-through, env default, size parsing.
- Full suite: **211 passed** (195 pre-existing unaffected).
- Downstream smoke on this branch: legend-dataflow (119 unit + 8 integration) and legend-dataflow-scripts (59 unit + 7 integration) all pass.

## Disclosure

Per `AI_POLICY.md`: this contribution was developed with AI assistance (Claude) and reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)