### PR TITLE
Added support for LH5 views

### DIFF
--- a/src/lh5/__init__.py
+++ b/src/lh5/__init__.py
@@ -15,6 +15,7 @@ from .io import (
     read_n_rows,
     show,
     write,
+    write_view,
 )
 
 __all__ = [
@@ -28,4 +29,5 @@ __all__ = [
     "read_n_rows",
     "show",
     "write",
+    "write_view",
 ]

--- a/src/lh5/io/__init__.py
+++ b/src/lh5/io/__init__.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import hdf5plugin  # noqa: F401
 
 from . import concat, truncate
-from .core import read, read_as, write
+from .core import read, read_as, write, write_view
 from .iterator import LH5Iterator, MapProgress
 from .settings import default_hdf5_settings
 from .store import LH5Store
@@ -33,4 +33,5 @@ __all__ = [
     "show",
     "truncate",
     "write",
+    "write_view",
 ]

--- a/src/lh5/io/_serializers/__init__.py
+++ b/src/lh5/io/_serializers/__init__.py
@@ -19,10 +19,12 @@ from .read.encoded import (
 )
 from .read.scalar import _h5_read_scalar
 from .read.vector_of_vectors import _h5_read_vector_of_vectors
+from .read.view import _h5_read_view
 from .write.array import _h5_write_array
 from .write.composite import _h5_write_lgdo, _h5_write_struct
 from .write.scalar import _h5_write_scalar
 from .write.vector_of_vectors import _h5_write_vector_of_vectors
+from .write.view import _h5_write_view
 
 __all__ = [
     "_h5_read_array",
@@ -38,9 +40,11 @@ __all__ = [
     "_h5_read_table",
     "_h5_read_vector_of_encoded_vectors",
     "_h5_read_vector_of_vectors",
+    "_h5_read_view",
     "_h5_write_array",
     "_h5_write_lgdo",
     "_h5_write_scalar",
     "_h5_write_struct",
     "_h5_write_vector_of_vectors",
+    "_h5_write_view",
 ]

--- a/src/lh5/io/_serializers/read/composite.py
+++ b/src/lh5/io/_serializers/read/composite.py
@@ -36,6 +36,7 @@ from .encoded import (
 )
 from .scalar import _h5_read_scalar
 from .vector_of_vectors import _h5_read_vector_of_vectors
+from .view import _h5_read_view
 
 log = logging.getLogger(__name__)
 
@@ -59,7 +60,22 @@ def _h5_read_lgdo(
 
     attrs = utils.read_attrs(h5o, fname, oname)
     try:
-        lgdotype = dtypeutils.datatype(attrs["datatype"])
+        dtype_attr = attrs["datatype"]
+        if dtype_attr[:4] == "view":
+            return _h5_read_view(
+                h5o,
+                fname,
+                oname,
+                view_type=dtype_attr,
+                start_row=start_row,
+                n_rows=n_rows,
+                idx=idx,
+                field_mask=field_mask,
+                obj_buf=obj_buf,
+                obj_buf_start=obj_buf_start,
+                decompress=decompress,
+            )
+        lgdotype = dtypeutils.datatype(dtype_attr)
     except KeyError as e:
         msg = "dataset not in file or missing 'datatype' attribute"
         raise LH5DecodeError(msg, fname, oname) from e

--- a/src/lh5/io/_serializers/read/ndarray.py
+++ b/src/lh5/io/_serializers/read/ndarray.py
@@ -110,7 +110,10 @@ def _h5_read_ndarray(
 
     # special handling for bools
     # (c and Julia store as uint8 so cast to bool)
-    if datatype.get_nested_datatype_string(attrs["datatype"]) == "bool":
+    if (
+        "datatype" in attrs
+        and datatype.get_nested_datatype_string(attrs["datatype"]) == "bool"
+    ):
         nda = nda.astype(np.bool_, copy=False)
 
     return (nda, attrs, n_rows_to_read)

--- a/src/lh5/io/_serializers/read/view.py
+++ b/src/lh5/io/_serializers/read/view.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import logging
+import sys
+
+import h5py
+import numpy as np
+
+from ...exceptions import LH5DecodeError
+from . import composite
+from .ndarray import _h5_read_ndarray
+
+log = logging.getLogger(__name__)
+
+
+def _h5_read_view(
+    h5g,
+    fname,
+    oname,
+    view_type,
+    start_row=0,
+    n_rows=sys.maxsize,
+    idx=None,
+    field_mask=None,
+    obj_buf=None,
+    obj_buf_start=0,
+    decompress=True,
+):
+    # Read the entries for the view
+    h5d_ent = h5py.h5d.open(h5g, b"entries")
+    entries, _, n_rows = _h5_read_ndarray(
+        h5d_ent,
+        fname,
+        f"{oname}/entries",
+        start_row=start_row,
+        n_rows=n_rows,
+        idx=idx,
+    )
+    h5d_ent.close()
+    if not np.issubdtype(entries.dtype, np.integer):
+        msg = "entries is not an integer array"
+        raise LH5DecodeError(msg, fname, oname)
+
+    # Check that the view type matches the shape of entries
+    if view_type == "view{entries}":
+        if len(entries.shape) != 1:
+            msg = "entries must be a 1D array of integers for view{entries}"
+            raise LH5DecodeError(msg, fname, oname)
+    elif view_type == "view{slices}":
+        if len(entries.shape) != 2 or entries.shape[1] != 2:
+            msg = "entries must be a 2D array of shape (n, 2) for view{slices}"
+            raise LH5DecodeError(msg, fname, oname)
+    else:
+        msg = f"unknown view type: {view_type}"
+        raise LH5DecodeError(msg, fname, oname)
+
+    # Now read the data, selecting the correct entries
+    try:
+        h5o = h5py.h5o.open(h5g, b"data")
+    except KeyError as e:
+        msg = f"view {oname} does not link to data"
+        raise LH5DecodeError(msg, fname, oname) from e
+
+    output = composite._h5_read_lgdo(
+        h5o,
+        fname,
+        oname,
+        start_row=0,
+        n_rows=sys.maxsize,
+        idx=entries,
+        field_mask=field_mask,
+        obj_buf=obj_buf,
+        obj_buf_start=obj_buf_start,
+        decompress=decompress,
+    )
+    h5o.close()
+    return output

--- a/src/lh5/io/_serializers/write/composite.py
+++ b/src/lh5/io/_serializers/write/composite.py
@@ -34,20 +34,9 @@ def _h5_write_lgdo(
         k: h5py_kwargs[k] for k in h5py_kwargs & signature(h5py.File).parameters.keys()
     }
     h5py_kwargs = {k: h5py_kwargs[k] for k in h5py_kwargs - file_kwargs.keys()}
-    if wo_mode == "write_safe":
-        wo_mode = "w"
-    if wo_mode == "append":
-        wo_mode = "a"
-    if wo_mode == "overwrite":
-        wo_mode = "o"
-    if wo_mode == "overwrite_file":
-        wo_mode = "of"
+    wo_mode = utils.normalize_womode(wo_mode)
+    if wo_mode == "of":
         write_start = 0
-    if wo_mode == "append_column":
-        wo_mode = "ac"
-    if wo_mode not in ["w", "a", "o", "of", "ac"]:
-        msg = f"unknown wo_mode '{wo_mode}'"
-        raise LH5EncodeError(msg, lh5_file, group, name)
 
     # "mode" is for the h5df.File and wo_mode is for this function
     # In hdf5, 'a' is really "modify" -- in addition to appending, you can

--- a/src/lh5/io/_serializers/write/view.py
+++ b/src/lh5/io/_serializers/write/view.py
@@ -51,9 +51,10 @@ def _h5_write_view(
         raise LH5EncodeError(msg, lh5_file, group, name)
 
     # create/get the view
-    overwrite = wo_mode in ("o", "overwrite")
+    wo_mode = utils.normalize_womode(wo_mode)
+    overwrite = wo_mode == "o"
     group = utils.get_h5_group(group, lh5_file)
-    if wo_mode in ("w", "write_safe") and name in group:
+    if wo_mode == "w" and name in group:
         msg = f"can't overwrite '{name}' in wo_mode 'write_safe'"
         raise LH5EncodeError(msg, lh5_file, group, name)
     view = utils.get_h5_group(

--- a/src/lh5/io/_serializers/write/view.py
+++ b/src/lh5/io/_serializers/write/view.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+import h5py
+import numpy as np
+from lgdo import Array
+
+from ... import utils
+from ...exceptions import LH5EncodeError
+from .array import _h5_write_array
+
+log = logging.getLogger(__name__)
+
+
+def _h5_write_view(
+    target: h5py.Group | h5py.Dataset | str,
+    entries: np.ndarray,
+    name: str,
+    lh5_file: h5py.File,
+    link_type: Literal[None, "hard", "soft", "external"] = None,
+    external_file: str | h5py.File | None = None,
+    group: str = "/",
+    start_row: int = 0,
+    n_rows: int | None = None,
+    wo_mode: str = "a",
+    write_start: int = 0,
+    **h5py_kwargs,
+):
+    if not (
+        isinstance(entries, np.ndarray) and issubclass(entries.dtype.type, np.integer)
+    ):
+        msg = "entries must be ints"
+        raise TypeError(msg)
+
+    # Check validity of entries
+    if len(entries) > 0 and not (
+        np.all(entries.ravel()[1:] > entries.ravel()[:-1]) and entries.ravel()[0] >= 0
+    ):
+        msg = "entries must be positive and in ascending order"
+        raise LH5EncodeError(msg, lh5_file, group, name)
+
+    # check type of view and define datatype string
+    if len(entries.shape) == 1:
+        view_type = "view{entries}"
+    elif len(entries.shape) == 2 and entries.shape[1] == 2:
+        view_type = "view{slices}"
+    else:
+        msg = "entries must have shape (n,) or (n, 2)"
+        raise LH5EncodeError(msg, lh5_file, group, name)
+
+    # create/get the view
+    overwrite = wo_mode in ("o", "overwrite")
+    group = utils.get_h5_group(group, lh5_file)
+    if wo_mode in ("w", "write_safe") and name in group:
+        msg = f"can't overwrite '{name}' in wo_mode 'write_safe'"
+        raise LH5EncodeError(msg, lh5_file, group, name)
+    view = utils.get_h5_group(
+        name, group, grp_attrs={"datatype": view_type}, overwrite=overwrite
+    )
+
+    # Deduce link type if needed
+    if isinstance(external_file, h5py.File):
+        external_file = external_file.filename
+    if link_type is None:
+        if isinstance(target, (h5py.Group, h5py.Dataset)):
+            if external_file is not None and external_file != target.file.filename:
+                msg = f"external_file {external_file} does not match target file {target.file.filename}"
+                raise LH5EncodeError(msg, lh5_file, group, name)
+            if external_file is None and target.file != lh5_file:
+                external_file = target.file.filename
+
+            link_type = "hard" if external_file is None else "external"
+        elif isinstance(target, str):
+            link_type = "soft" if external_file is None else "external"
+
+    # Add the link
+    if link_type == "external":
+        if external_file is None:
+            msg = "external_file required for external links"
+            raise ValueError(msg)
+        if isinstance(target, (h5py.Group, h5py.Dataset)):
+            target = target.name
+
+        link = view.get("data", getlink=True)
+        if link is None:
+            view["data"] = h5py.ExternalLink(external_file, target)
+        elif not (
+            isinstance(link, h5py.ExternalLink)
+            and link.path == target
+            and link.filename == external_file
+        ):
+            if not overwrite:
+                msg = "existing HDF5 link is different from target. Cannot append"
+                raise LH5EncodeError(msg, lh5_file, group, name)
+            del view["data"]
+            view["data"] = h5py.ExternalLink(external_file, target)
+
+    elif link_type == "hard":
+        if external_file is not None:
+            msg = "external_file must be None for hard links"
+            raise ValueError(msg)
+        if not isinstance(target, (h5py.Group, h5py.Dataset)):
+            target = utils.get_h5_group(target, lh5_file)
+
+        link = view.get("data", getlink=True)
+        if link is None:
+            view["data"] = target
+        elif not (isinstance(link, h5py.HardLink) and view["data"].id == target.id):
+            if not overwrite:
+                msg = "existing HDF5 link is different from target"
+                raise LH5EncodeError(msg, lh5_file, group, name)
+            del view["data"]
+            view["data"] = target
+
+    elif link_type == "soft":
+        if external_file is not None:
+            msg = "external_file must be None for soft links"
+            raise ValueError(msg)
+        if isinstance(target, (h5py.Group, h5py.Dataset)):
+            target = target.name
+
+        link = view.get("data", getlink=True)
+        if link is None:
+            view["data"] = h5py.SoftLink(target)
+        elif not (isinstance(link, h5py.SoftLink) and link.path == target):
+            if not overwrite:
+                msg = "existing HDF5 link is different from target"
+                raise LH5EncodeError(msg, lh5_file, group, name)
+            del view["data"]
+            view["data"] = h5py.SoftLink(target)
+
+    # write entries
+    _h5_write_array(
+        Array(entries),
+        "entries",
+        lh5_file,
+        group=view,
+        start_row=start_row,
+        n_rows=n_rows,
+        wo_mode=wo_mode,
+        write_start=write_start,
+        **h5py_kwargs,
+    )
+
+    # remove datatype from the entry attrs; it is not a part of the view spec
+    entries_attrs = view["entries"].attrs
+    if "datatype" in entries_attrs:
+        del view["entries"].attrs["datatype"]

--- a/src/lh5/io/core.py
+++ b/src/lh5/io/core.py
@@ -16,7 +16,7 @@ from numpy.typing import ArrayLike
 
 from . import _serializers
 from .exceptions import LH5DecodeError
-from .utils import read_n_rows
+from .utils import normalize_womode, read_n_rows
 
 log = logging.getLogger(__name__)
 
@@ -335,10 +335,10 @@ def write(
         as an `obj` attribute.**
     """
 
-    if (
-        isinstance(lh5_file, (str, Path))
-        and not Path(lh5_file).is_file()
-        and wo_mode in ("w", "write_safe", "of", "overwrite_file")
+    wo_mode = normalize_womode(wo_mode)
+    if page_buffer > 0 and (
+        (isinstance(lh5_file, (str, Path)) and not Path(lh5_file).is_file())
+        or wo_mode in ("w", "of")
     ):
         h5py_kwargs.update(
             {

--- a/src/lh5/io/core.py
+++ b/src/lh5/io/core.py
@@ -5,7 +5,8 @@ import inspect
 import logging
 import sys
 from collections.abc import Mapping, Sequence
-from contextlib import suppress
+from contextlib import nullcontext, suppress
+from inspect import signature
 from pathlib import Path
 from typing import Any
 
@@ -405,3 +406,129 @@ def read_as(
 
     # and finally return a view
     return obj.view_as(library, **kwargs2)
+
+
+def write_view(
+    target: str | h5py.Group | h5py.Dataset,
+    entries: np.ndarray,
+    name: str,
+    lh5_file: str | Path | h5py.File,
+    link_type: str = None,
+    external_file: str | Path | None = None,
+    group: str | h5py.Group = "/",
+    start_row: int = 0,
+    n_rows: int | None = None,
+    wo_mode: str = "append",
+    write_start: int = 0,
+    page_buffer: int = 0,
+    **h5py_kwargs,
+):
+    """Create a view of an array or table in an LH5 file.
+    A LH5 view is a reference to an existing array or table in the
+    same or another LH5 file, along with an entry list specifying the
+    rows to read out. The entry list can be stored as a 1D array of
+    row indices or a 2D array of row ranges (start, end); the entries
+    correspond to the outer-most dimension of the target array or table only.
+
+    Parameters
+    ----------
+    target
+        The target array or table to be referenced. Can be a string
+        corresponding to the path of the target in the file, or an
+        :class:`h5py.Group` or :class:`h5py.Dataset` object. A string
+        must be provided if the view is a SoftLink or ExternalLink.
+    entries
+        A 1D array of row indices or a (n,2) shape array of row ranges (start, end).
+        Indices must be in ascending order.
+    name
+        Name of the view in the output LH5 file.
+    lh5_file
+        HDF5 file name or :class:`h5py.File` object.
+    link_type
+        Type of link used to reference the target. Can be ``hard`` (default),
+        ``soft`` or ``external``. If ``external``, the `external_file` arg
+        is required.
+    external_file
+        External HDF5 file containing target referenced by view. Only used
+        if `link_type` is ``external``.
+    group
+        HDF5 group name or :class:`h5py.Group` object in which `obj` should
+        be written.
+    start_row
+        first row in `obj` to be written.
+    n_rows
+        number of rows in `obj` to be written.
+    wo_mode
+        - ``write_safe`` or ``w``: only proceed with writing if the
+          object does not already exist in the file.
+        - ``append`` or ``a``: append along axis 0 (the first dimension)
+          of array-like objects and array-like subfields of structs.
+          :class:`~.lgdo.scalar.Scalar` objects get overwritten.
+        - ``overwrite`` or ``o``: replace data in the file if present,
+          starting from `write_start`. Note: overwriting with `write_start` =
+          end of array is the same as ``append``.
+        - ``overwrite_file`` or ``of``: delete file if present prior to
+          writing to it. `write_start` should be 0 (it's ignored).
+        - ``append_column`` or ``ac``: append fields/columns from an
+          :class:`~.lgdo.struct.Struct` `obj` (and derived types such as
+          :class:`~.lgdo.table.Table`) only if there is an existing
+          :class:`~.lgdo.struct.Struct` in the `lh5_file` with the same `name`.
+          If there are matching fields, it errors out. If appending to a
+          ``Table`` and the size of the new column is different from the size
+          of the existing table, it errors out.
+    write_start
+        row in the output file (if already existing) to start overwriting
+        from.
+    page_buffer
+        enable paged aggregation with a buffer of this size in bytes.
+        Only used when creating a new file. Useful when writing a file
+        with a large number of small datasets. This is a short-hand for
+        ``(fs_strategy="page", fs_page_size=page_buffer)``
+    **h5py_kwargs
+        additional keyword arguments forwarded to
+        :meth:`h5py.Group.create_dataset` to specify, for example, an HDF5
+        compression filter to be applied before writing non-scalar
+        datasets. **Note: `compression` ignored if compression is specified
+        as an `obj` attribute.**
+    """
+
+    if (
+        isinstance(lh5_file, str)
+        and not Path(lh5_file).is_file()
+        and wo_mode in ("w", "write_safe", "of", "overwrite_file")
+    ):
+        h5py_kwargs.update(
+            {
+                "fs_strategy": "page",
+                "fs_page_size": page_buffer,
+            }
+        )
+
+    file_kwargs = {
+        k: h5py_kwargs[k] for k in h5py_kwargs & signature(h5py.File).parameters.keys()
+    }
+    h5py_kwargs = {k: h5py_kwargs[k] for k in h5py_kwargs - file_kwargs.keys()}
+
+    with (
+        h5py.File(
+            lh5_file,
+            mode="w" if wo_mode == "of" or not Path(lh5_file).exists() else "a",
+            **file_kwargs,
+        )
+        if not isinstance(lh5_file, h5py.File)
+        else nullcontext(lh5_file) as fh
+    ):
+        return _serializers._h5_write_view(
+            target,
+            entries,
+            name,
+            fh,
+            link_type=link_type,
+            external_file=external_file,
+            group=group,
+            start_row=start_row,
+            n_rows=n_rows,
+            wo_mode=wo_mode,
+            write_start=write_start,
+            **h5py_kwargs,
+        )

--- a/src/lh5/io/core.py
+++ b/src/lh5/io/core.py
@@ -491,11 +491,10 @@ def write_view(
         datasets. **Note: `compression` ignored if compression is specified
         as an `obj` attribute.**
     """
-
-    if (
-        isinstance(lh5_file, str)
-        and not Path(lh5_file).is_file()
-        and wo_mode in ("w", "write_safe", "of", "overwrite_file")
+    wo_mode = normalize_womode(wo_mode)
+    if page_buffer > 0 and (
+        (isinstance(lh5_file, (str, Path)) and not Path(lh5_file).is_file())
+        or wo_mode in ("w", "of")
     ):
         h5py_kwargs.update(
             {

--- a/src/lh5/io/core.py
+++ b/src/lh5/io/core.py
@@ -336,7 +336,7 @@ def write(
     """
 
     if (
-        isinstance(lh5_file, str)
+        isinstance(lh5_file, (str, Path))
         and not Path(lh5_file).is_file()
         and wo_mode in ("w", "write_safe", "of", "overwrite_file")
     ):

--- a/src/lh5/io/datatype.py
+++ b/src/lh5/io/datatype.py
@@ -8,7 +8,7 @@ from lgdo import types
 
 _lgdo_datatype_map: dict[str, types.LGDO] = OrderedDict(
     [
-        (types.Scalar, r"^real$|^bool$|^complex$|^bool$|^string$"),
+        (types.Scalar, r"^real$|^bool$|^complex$|^string$"),
         (types.VectorOfVectors, r"^array<1>\{array<1>\{.+\}\}$"),
         (types.VectorOfEncodedVectors, r"^array<1>\{encoded_array<1>\{.+\}\}$"),
         (

--- a/src/lh5/io/exceptions.py
+++ b/src/lh5/io/exceptions.py
@@ -36,7 +36,7 @@ class LH5EncodeError(Exception):
 
         self.file = file.filename if isinstance(file, h5py.File) else file
         self.group = (
-            (group.name if isinstance(file, h5py.File) else group).rstrip("/")
+            (group.name if isinstance(group, h5py.Group) else group).rstrip("/")
             if group is not None
             else None
         )

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -8,8 +8,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from functools import partial
 from itertools import chain
-from multiprocessing import Manager, Queue
-from queue import Empty
+from queue import Empty, Queue
 from threading import Event, Thread
 from typing import Any
 
@@ -1278,17 +1277,17 @@ class LH5Iterator(Iterator):
         test = where(self.lh5_buffer, self)
 
         with ExitStack() as stack:
-            prog = (
-                stack.enter_context(MapProgress(processes, progress))
-                if progress
-                else None
-            )
-
             if processes is None and isinstance(executor, Executor):
                 processes = executor._max_workers
 
             if executor is None and isinstance(processes, int):
                 executor = stack.enter_context(ProcessPoolExecutor(processes))
+
+            prog = (
+                stack.enter_context(MapProgress(processes, executor, progress))
+                if progress
+                else None
+            )
 
             pq = prog.queue if prog else None
             if isinstance(test, LGDOCollection):
@@ -1680,6 +1679,7 @@ class MapProgress(Thread):
     def __init__(
         self,
         tasks: list | int,
+        executor: Executor,
         prog: progress.Progress | console.Console = None,
         update_period: float = 0.1,
     ):
@@ -1722,8 +1722,26 @@ class MapProgress(Thread):
             )
         self.update_period = update_period
 
-        self.manager = Manager()
-        self.queue = self.manager.Queue()
+        self.manager = None
+        self.queue = None
+        if executor is None:
+            self.queue = Queue()
+        elif type(executor).__name__ == "ProcessPoolExecutor":
+            import multiprocessing  # noqa: PLC0415
+
+            self.manager = multiprocessing.Manager()
+            self.queue = self.manager.Queue()
+        elif type(executor).__name__ == "InterpreterPoolExecutor":
+            self.manager = None
+            from concurrent import interpreters  # noqa: PLC0415
+
+            self.queue = interpreters.create_queue()
+        elif type(executor).__name__ == "ThreadPoolExecutor":
+            self.queue = Queue()
+        else:
+            log.warning(
+                f"Cannot pass messages from {type(executor).__name__} to progress bar. Progress will not be shown."
+            )
         self.done = Event()
         super().__init__(daemon=True)
 
@@ -1735,7 +1753,7 @@ class MapProgress(Thread):
             while True:
                 try:
                     progress_info = self.queue.get(block=False)
-                except Empty:
+                except (AttributeError, Empty):
                     break
                 self.progress.update(**progress_info)
             self.progress.refresh()
@@ -1744,7 +1762,7 @@ class MapProgress(Thread):
         while True:
             try:
                 progress_info = self.queue.get(block=False)
-            except Empty:
+            except (AttributeError, Empty):
                 break
             self.progress.update(**progress_info)
         self.progress.refresh()

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -1164,7 +1164,13 @@ class LH5Iterator(Iterator):
             )
 
         if processes is None:
-            processes = executor._max_workers
+            if hasattr(executor, "_max_workers"):
+                processes = executor._max_workers
+            elif hasattr(executor, "_threads"):
+                processes = len(executor._threads)
+            else:
+                msg = f"Must explicitly provide number of processes for {type(executor).__name__}"
+                raise ValueError(msg)
 
         it_pool = self._generate_workers(processes)
 

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -1204,6 +1204,11 @@ class LH5Iterator(Iterator):
 
         Returns the selected data as a single table in one of several formats.
 
+        .. danger::
+
+            This function uses :func:`eval` to evaluate string expressions. Do not
+            use with untrusted input, as this can lead to arbitrary code execution.
+
         Examples
         --------
         Query data using a string selection::
@@ -1346,6 +1351,11 @@ class LH5Iterator(Iterator):
         """
         Fill a histogram from data produced by a query selecting on ``where``. If
         ``where`` is ``None``, fill with all data fetched by iterator.
+
+        .. danger::
+
+            This function uses :func:`eval` to evaluate string expressions. Do not
+            use with untrusted input, as this can lead to arbitrary code execution.
 
         Examples
         --------

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -359,7 +359,8 @@ class LH5Iterator(Iterator):
                     self.local_entry_list[i_ds] = np.nonzero(local_mask)[0]
 
     def __del__(self):
-        self.lh5_st.close()
+        if hasattr(self, "lh5_st") and self.lh5_st is not None:
+            self.lh5_st.close()
 
     def get_file(self, i_ds: int) -> str:
         """Get file name for dataset i_ds"""

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -423,7 +423,7 @@ class LH5Iterator(Iterator):
                     val = np.iinfo(dtype).max
                 elif dtype.kind == "i":
                     val = np.iinfo(dtype).min
-                elif dtype.kind in ("f", "S"):
+                elif dtype.kind in ("f", "c"):
                     val = np.nan
                 elif dtype.kind in ("S", "T", "U"):
                     val = ""

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -1111,10 +1111,10 @@ class LH5Iterator(Iterator):
         executor:
             :class:`concurrent.futures.Executor` object for managing parallelism.
         executor_mode:
-            mode for transfering data between threads/processes, based on executor. This
+            mode for transferring data between threads/processes, based on executor. This
             affects how aggregators, and internal states if objects are passed. Options:
             - process: multiprocessing-like; the executor is assumed to handle inter-process
-              communciation (likely through pickling), and objects are assumed to be isolated
+              communication (likely through pickling), and objects are assumed to be isolated
             - thread: threading-like; memory is shared between threads, so we explicitly
               copy data before sending to threads to ensure isolation
             - ``None``: default; use process for ProcessPoolExecutor and
@@ -1275,10 +1275,10 @@ class LH5Iterator(Iterator):
             If ``None``, create a :class:`concurrent.futures.ProcessPoolExecutor`
             with number of processes equal to ``processes``.
         executor_mode:
-            mode for transfering data between threads/processes, based on executor. This
+            mode for transferring data between threads/processes, based on executor. This
             affects how aggregators, and internal states if objects are passed. Options:
             - process: multiprocessing-like; the executor is assumed to handle inter-process
-              communciation (likely through pickling), and objects are assumed to be isolated
+              communication (likely through pickling), and objects are assumed to be isolated
             - thread: threading-like; memory is shared between threads, so we explicitly
               copy data before sending to threads to ensure isolation
             - ``None``: default; use process for ProcessPoolExecutor and
@@ -1440,10 +1440,10 @@ class LH5Iterator(Iterator):
             If ``None``, create a :class:`concurrent.futures.ProcessPoolExecutor`
             with number of processes equal to ``processes``.
         executor_mode:
-            mode for transfering data between threads/processes, based on executor. This
+            mode for transferring data between threads/processes, based on executor. This
             affects how aggregators, and internal states if objects are passed. Options:
             - process: multiprocessing-like; the executor is assumed to handle inter-process
-              communciation (likely through pickling), and objects are assumed to be isolated
+              communication (likely through pickling), and objects are assumed to be isolated
             - thread: threading-like; memory is shared between threads, so we explicitly
               copy data before sending to threads to ensure isolation
             - ``None``: default; use process for ProcessPoolExecutor and

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -359,6 +359,9 @@ class LH5Iterator(Iterator):
                 for i_ds, local_mask in enumerate(entry_mask):
                     self.local_entry_list[i_ds] = np.nonzero(local_mask)[0]
 
+    def __del__(self):
+        self.lh5_st.close()
+
     def get_file(self, i_ds: int) -> str:
         """Get file name for dataset i_ds"""
         if i_ds < 0 or i_ds >= self.n_datasets:
@@ -723,11 +726,7 @@ class LH5Iterator(Iterator):
             remaining_fields = set()
 
         elif isinstance(mask, Mapping):
-            for k, v in mask.items():
-                new_k = k.replace(".", "/")
-                if new_k != k:
-                    mask[new_k] = v
-                    del mask[k]
+            mask = {k.replace(".", "/"): v for k, v in mask.items()}
 
             self.field_mask = {
                 field: mask[field] for field in self.available_fields if field in mask

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -1113,11 +1113,14 @@ class LH5Iterator(Iterator):
         executor_mode:
             mode for transferring data between threads/processes, based on executor. This
             affects how aggregators, and internal states if objects are passed. Options:
+
             - process: multiprocessing-like; the executor is assumed to handle inter-process
               communication (likely through pickling), and objects are assumed to be isolated
             - thread: threading-like; memory is shared between threads, so we explicitly
               copy data before sending to threads to ensure isolation
-            - ``None``: default; use process for ProcessPoolExecutor and
+            - ``None``: default; use process for ProcessPoolExecutor and InterpreterPoolExecutor,
+              and thread for ThreadPoolExecutor; must be explicit for others!
+
         progress_queue:
             :class:`multiprocessing.Queue` object to which progress information will be
             communicated back to main process. Returns a mapping with keys:
@@ -1277,11 +1280,14 @@ class LH5Iterator(Iterator):
         executor_mode:
             mode for transferring data between threads/processes, based on executor. This
             affects how aggregators, and internal states if objects are passed. Options:
+
             - process: multiprocessing-like; the executor is assumed to handle inter-process
               communication (likely through pickling), and objects are assumed to be isolated
             - thread: threading-like; memory is shared between threads, so we explicitly
               copy data before sending to threads to ensure isolation
-            - ``None``: default; use process for ProcessPoolExecutor and
+            - ``None``: default; use process for ProcessPoolExecutor and InterpreterPoolExecutor,
+              and thread for ThreadPoolExecutor; must be explicit for others!
+
         library:
             library to convert the columns to when using a string expression for ``where``.
             See :meth:`Table.eval`.
@@ -1442,11 +1448,14 @@ class LH5Iterator(Iterator):
         executor_mode:
             mode for transferring data between threads/processes, based on executor. This
             affects how aggregators, and internal states if objects are passed. Options:
+
             - process: multiprocessing-like; the executor is assumed to handle inter-process
               communication (likely through pickling), and objects are assumed to be isolated
             - thread: threading-like; memory is shared between threads, so we explicitly
               copy data before sending to threads to ensure isolation
-            - ``None``: default; use process for ProcessPoolExecutor and
+            - ``None``: default; use process for ProcessPoolExecutor and InterpreterPoolExecutor,
+              and thread for ThreadPoolExecutor; must be explicit for others!
+
         progress:
             if ``True`` draw progress bar; can also provide an existing rich ``Progress``
             or ``Console`` object

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -576,8 +576,9 @@ class LH5Iterator(Iterator):
         self.current_i_entry = i_entry
 
         for friend in self.friend:
-            friend.read(i_entry)
+            friend.read(i_entry, n_entries)
 
+            # check if entries in all datasets to current are all equal
             if (
                 self.safe_mode
                 and self._get_ds_cumentries(i_ds) != friend._get_ds_cumentries(i_ds)

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -1160,7 +1160,10 @@ class LH5Iterator(Iterator):
         it_pool = self._generate_workers(processes)
 
         if executor_mode is None:
-            if type(executor).__name__ in ("ProcessPoolExecutor", "InterpreterPoolExecutor"):
+            if type(executor).__name__ in (
+                "ProcessPoolExecutor",
+                "InterpreterPoolExecutor",
+            ):
                 executor_mode = "process"
             elif type(executor).__name__ == "ThreadPoolExecutor":
                 executor_mode = "thread"

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -329,6 +329,8 @@ class LH5Iterator(Iterator):
         self.n_entries = n_entries
         self.current_i_entry = 0
         self.next_i_entry = 0
+        self.current_local_entries = np.empty(0, "q")
+        self.current_global_entries = np.empty(0, "q")
 
         # List of entry indices from each file
         self.local_entry_list = None
@@ -526,6 +528,10 @@ class LH5Iterator(Iterator):
             msg = "n_entries cannot be larger than buffer_len"
             raise ValueError(msg)
 
+        if len(self.current_local_entries) < n_entries:
+            self.current_local_entries = np.empty(n_entries, "q")
+            self.current_global_entries = np.empty(n_entries, "q")
+
         # if dataset hasn't been opened yet, search through datasets
         # sequentially until we find the right one
         i_ds = np.searchsorted(self.entry_map, i_entry, "right")
@@ -565,6 +571,23 @@ class LH5Iterator(Iterator):
                     min(n_entries, self._get_ds_cumentries(i_ds) - i_entry)
                 )
 
+            if local_idx is None:
+                self.current_local_entries[buf_start : len(self.lh5_buffer)] = (
+                    np.arange(
+                        local_i_entry, local_i_entry + len(self.lh5_buffer) - buf_start
+                    )
+                )
+            else:
+                self.current_local_entries[buf_start : len(self.lh5_buffer)] = (
+                    local_idx[
+                        local_i_entry : local_i_entry + len(self.lh5_buffer) - buf_start
+                    ]
+                )
+            self.current_global_entries[buf_start : len(self.lh5_buffer)] = (
+                self.current_local_entries[buf_start : len(self.lh5_buffer)]
+                + self._get_ds_cumlen(i_ds - 1)
+            )
+
             if self.group_data is not None:
                 data = self.get_group_data(i_ds)
                 for f in data.fields:
@@ -574,6 +597,13 @@ class LH5Iterator(Iterator):
             local_i_entry = 0
 
         self.current_i_entry = i_entry
+        if len(self.current_local_entries) > len(self.lh5_buffer):
+            self.current_local_entries = np.resize(
+                self.current_local_entries, len(self.lh5_buffer)
+            )
+            self.current_global_entries = np.resize(
+                self.current_global_entries, len(self.lh5_buffer)
+            )
 
         for friend in self.friend:
             friend.read(i_entry, n_entries)
@@ -818,64 +848,6 @@ class LH5Iterator(Iterator):
 
         if warn_missing and len(remaining_fields) > 0:
             log.warning(f"Fields {remaining_fields} in field mask were not found")
-
-    @property
-    def current_local_entries(self) -> NDArray[int]:
-        """Return list of local dataset entries in buffer"""
-        cur_entries = np.zeros(len(self.lh5_buffer), dtype="int32")
-        i_ds = np.searchsorted(self.entry_map, self.current_i_entry, "right")
-        ds_start = self._get_ds_cumentries(i_ds - 1)
-        i_local = self.current_i_entry - ds_start
-        i = 0
-
-        while i < len(cur_entries):
-            # number of entries to read from this file
-            ds_end = self._get_ds_cumentries(i_ds)
-            n = min(ds_end - ds_start - i_local, len(cur_entries) - i)
-            entries = self.get_ds_entrylist(i_ds)
-
-            if entries is None:
-                cur_entries[i : i + n] = np.arange(i_local, i_local + n)
-            else:
-                cur_entries[i : i + n] = entries[i_local : i_local + n]
-
-            i_ds += 1
-            ds_start = ds_end
-            i_local = 0
-            i += n
-
-        return cur_entries
-
-    @property
-    def current_global_entries(self) -> NDArray[int]:
-        """Return list of global file entries in buffer"""
-        cur_entries = np.zeros(len(self.lh5_buffer), dtype="int32")
-        i_ds = np.searchsorted(self.entry_map, self.current_i_entry, "right")
-        ds_start = self._get_ds_cumentries(i_ds - 1)
-        i_local = self.current_i_entry - ds_start
-        i = 0
-
-        while i < len(cur_entries):
-            # number of entries to read from this file
-            ds_end = self._get_ds_cumentries(i_ds)
-            n = min(ds_end - ds_start - i_local, len(cur_entries) - i)
-            entries = self.get_ds_entrylist(i_ds)
-
-            if entries is None:
-                cur_entries[i : i + n] = self._get_ds_cumlen(i_ds - 1) + np.arange(
-                    i_local, i_local + n
-                )
-            else:
-                cur_entries[i : i + n] = (
-                    self._get_ds_cumlen(i_ds - 1) + entries[i_local : i_local + n]
-                )
-
-            i_ds += 1
-            ds_start = ds_end
-            i_local = 0
-            i += n
-
-        return cur_entries
 
     @property
     def current_files(self) -> NDArray[str]:

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -336,7 +336,7 @@ class LH5Iterator(Iterator):
         self.global_entry_list = None
         if entry_list is not None:
             entry_list = list(entry_list)
-            if isinstance(entry_list[0], int):
+            if len(entry_list) > 0 and isinstance(entry_list[0], (int, np.integer)):
                 self.local_entry_list = [None] * self.n_datasets
                 self.global_entry_list = np.array(entry_list, "q")
                 self.global_entry_list.sort()

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -450,6 +450,8 @@ class LH5Iterator(Iterator):
             fcl = self.ds_map[i_start - 1] if i_start > 0 else 0
 
             for i in range(i_start, i_ds + 1):
+                if i >= self.n_datasets:
+                    break
                 fcl += self.lh5_st.read_n_rows(self.get_group(i), self.get_file(i))
                 self.ds_map[i] = fcl
         return fcl
@@ -484,7 +486,7 @@ class LH5Iterator(Iterator):
 
     def get_ds_entrylist(self, i_ds: int) -> np.ndarray:
         """Helper to get entry list for dataset"""
-        if i_ds < 0 or i_ds > self.n_datasets:
+        if i_ds < 0 or i_ds >= self.n_datasets:
             msg = f"dataset index {i_ds} out of range"
             raise IndexError(msg)
 
@@ -641,6 +643,8 @@ class LH5Iterator(Iterator):
                 if size_in_bytes > 0:
                     buffer_len = int(buffer_len / (size_in_bytes * ureg.B))
                     break
+            if isinstance(buffer_len, ureg.Quantity):
+                buffer_len = int(buffer_len / ureg.B)
 
         self._buffer_len = buffer_len
         for fr in self.friend:
@@ -1016,11 +1020,11 @@ class LH5Iterator(Iterator):
 
     def map(
         self,
-        fun: Callable[Table, LH5Iterator, Any],
+        fun: Callable[[Table, LH5Iterator], Any],
         aggregate: Callable = None,
         init: Any = None,
-        begin: Callable[LH5Iterator] = None,
-        terminate: Callable[LH5Iterator] = None,
+        begin: Callable[[LH5Iterator], None] = None,
+        terminate: Callable[[LH5Iterator], None] = None,
         processes: int = None,
         executor: Executor = None,
         progress_queue: Queue = None,

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -1739,7 +1739,7 @@ class MapProgress(Thread):
             self.progress = prog
         else:
             self.progress = progress.Progress(
-                progress.TextColumn("{task.description}: {task.fields[status]}"),
+                progress.TextColumn("{task.description:>5}: {task.fields[status]:<12}"),
                 progress.BarColumn(),
                 progress.TaskProgressColumn(),
                 progress.TextColumn(

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -10,7 +10,7 @@ from functools import partial
 from itertools import chain
 from queue import Empty, Queue
 from threading import Event, Thread
-from typing import Any
+from typing import Any, Literal
 
 import awkward as ak
 import numpy as np
@@ -1027,6 +1027,7 @@ class LH5Iterator(Iterator):
         terminate: Callable[[LH5Iterator], None] = None,
         processes: int = None,
         executor: Executor = None,
+        executor_mode: Literal["process", "thread", None] = None,
         progress_queue: Queue = None,
         job_id: int | Collection[int] = 0,
     ) -> Iterator[Any]:
@@ -1109,6 +1110,14 @@ class LH5Iterator(Iterator):
             all available processes/threads.
         executor:
             :class:`concurrent.futures.Executor` object for managing parallelism.
+        executor_mode:
+            mode for transfering data between threads/processes, based on executor. This
+            affects how aggregators, and internal states if objects are passed. Options:
+            - process: multiprocessing-like; the executor is assumed to handle inter-process
+              communciation (likely through pickling), and objects are assumed to be isolated
+            - thread: threading-like; memory is shared between threads, so we explicitly
+              copy data before sending to threads to ensure isolation
+            - ``None``: default; use process for ProcessPoolExecutor and
         progress_queue:
             :class:`multiprocessing.Queue` object to which progress information will be
             communicated back to main process. Returns a mapping with keys:
@@ -1150,21 +1159,44 @@ class LH5Iterator(Iterator):
 
         it_pool = self._generate_workers(processes)
 
-        result = executor.map(
-            partial(
+        if executor_mode is None:
+            if type(executor).__name__ in ("ProcessPoolExecutor", "InterpreterPoolExecutor"):
+                executor_mode = "process"
+            elif type(executor).__name__ == "ThreadPoolExecutor":
+                executor_mode = "thread"
+            else:
+                msg = f"Could not deduce executor_mode for {type(executor).__name__}. Please specify"
+                raise ValueError(msg)
+
+        if executor_mode == "process":
+            result = executor.map(
+                partial(
+                    _map_helper,
+                    fun,
+                    aggregate,
+                    init,
+                    begin,
+                    terminate,
+                    progress_queue=progress_queue,
+                ),
+                it_pool,
+                job_id
+                if isinstance(job_id, Collection)
+                else range(job_id, job_id + processes),
+            )
+        elif executor_mode == "thread":
+            result = executor.map(
                 _map_helper,
-                fun,
-                aggregate,
-                init,
-                begin,
-                terminate,
-                progress_queue=progress_queue,
-            ),
-            it_pool,
-            job_id
-            if isinstance(job_id, Collection)
-            else range(job_id, job_id + processes),
-        )
+                [deepcopy(fun) for _ in range(processes)],
+                [deepcopy(aggregate) for _ in range(processes)],
+                [deepcopy(init) for _ in range(processes)],
+                [deepcopy(begin) for _ in range(processes)],
+                [deepcopy(terminate) for _ in range(processes)],
+                it_pool,
+                job_id
+                if isinstance(job_id, Collection)
+                else range(job_id, job_id + processes),
+            )
 
         # If no aggregator was given, chain iterators
         if aggregate is _append_copy:
@@ -1178,6 +1210,7 @@ class LH5Iterator(Iterator):
         fields: Collection[str] | Mapping[str, str | None] = None,
         processes: Executor | int = None,
         executor: Executor = None,
+        executor_mode: Literal["process", "thread", None] = None,
         library: str = None,
         progress: progress.Progress | console.Console | bool = True,
     ):
@@ -1238,6 +1271,14 @@ class LH5Iterator(Iterator):
             :class:`concurrent.futures.Executor` object for managing parallelism.
             If ``None``, create a :class:`concurrent.futures.ProcessPoolExecutor`
             with number of processes equal to ``processes``.
+        executor_mode:
+            mode for transfering data between threads/processes, based on executor. This
+            affects how aggregators, and internal states if objects are passed. Options:
+            - process: multiprocessing-like; the executor is assumed to handle inter-process
+              communciation (likely through pickling), and objects are assumed to be isolated
+            - thread: threading-like; memory is shared between threads, so we explicitly
+              copy data before sending to threads to ensure isolation
+            - ``None``: default; use process for ProcessPoolExecutor and
         library:
             library to convert the columns to when using a string expression for ``where``.
             See :meth:`Table.eval`.
@@ -1272,6 +1313,7 @@ class LH5Iterator(Iterator):
                     where,
                     processes=processes,
                     executor=executor,
+                    executor_mode=executor_mode,
                     aggregate=Table.append,
                     progress_queue=pq,
                 )
@@ -1327,6 +1369,7 @@ class LH5Iterator(Iterator):
         keys: Collection[str] | str = None,
         processes: Executor | int = None,
         executor: Executor = None,
+        executor_mode: Literal["process", "thread", None] = None,
         progress: progress.Progress | console.Console | bool = True,
         **hist_kwargs,
     ) -> Hist:
@@ -1393,6 +1436,14 @@ class LH5Iterator(Iterator):
             :class:`concurrent.futures.Executor` object for managing parallelism.
             If ``None``, create a :class:`concurrent.futures.ProcessPoolExecutor`
             with number of processes equal to ``processes``.
+        executor_mode:
+            mode for transfering data between threads/processes, based on executor. This
+            affects how aggregators, and internal states if objects are passed. Options:
+            - process: multiprocessing-like; the executor is assumed to handle inter-process
+              communciation (likely through pickling), and objects are assumed to be isolated
+            - thread: threading-like; memory is shared between threads, so we explicitly
+              copy data before sending to threads to ensure isolation
+            - ``None``: default; use process for ProcessPoolExecutor and
         progress:
             if ``True`` draw progress bar; can also provide an existing rich ``Progress``
             or ``Console`` object
@@ -1431,6 +1482,7 @@ class LH5Iterator(Iterator):
                 where,
                 processes=processes,
                 executor=executor,
+                executor_mode=executor_mode,
                 aggregate=_hist_filler(keys),
                 init=h,
                 progress_queue=prog.queue if prog else None,

--- a/src/lh5/io/iterator.py
+++ b/src/lh5/io/iterator.py
@@ -1478,17 +1478,17 @@ class LH5Iterator(Iterator):
             where = _table_query(where, "ak", None)
 
         with ExitStack() as stack:
+            if executor is None and isinstance(processes, int):
+                executor = stack.enter_context(ProcessPoolExecutor(processes))
+
             prog = (
-                stack.enter_context(MapProgress(processes, progress))
+                stack.enter_context(MapProgress(processes, executor, progress))
                 if progress
                 else None
             )
 
             if processes is None and isinstance(executor, Executor):
                 processes = executor._max_workers
-
-            if executor is None and isinstance(processes, int):
-                executor = stack.enter_context(ProcessPoolExecutor(processes))
 
             h = self.map(
                 where,

--- a/src/lh5/io/settings.py
+++ b/src/lh5/io/settings.py
@@ -21,7 +21,7 @@ def default_hdf5_settings() -> dict[str, Any]:
     }
 
 
-DEFAULT_HDF5_SETTINGS: dict[str, ...] = default_hdf5_settings()
+DEFAULT_HDF5_SETTINGS: dict[str, Any] = default_hdf5_settings()
 """Global dictionary storing the default HDF5 settings for writing data to disk.
 
 Modify this global variable before writing data to disk with this package.

--- a/src/lh5/io/store.py
+++ b/src/lh5/io/store.py
@@ -6,6 +6,7 @@ HDF5 files.
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from collections import OrderedDict
 from collections.abc import Mapping, Sequence
@@ -61,8 +62,11 @@ class LH5Store:
             :class:`h5py.File` documentation. If default_mode is ``"r"``, use
             ``"a"`` when calling `LH5Store.write`.
         """
-        base_path = str(Path(base_path)) if base_path != "" else ""
-        self.base_path = "" if base_path == "" else utils.expand_path(base_path)
+        self.base_path = Path(os.path.expandvars(base_path)).resolve()
+        if not self.base_path.exists():
+            msg = f"base path {self.base_path} does not exist"
+            raise FileNotFoundError(msg)
+
         self.keep_open = keep_open
         self.locking = locking
         self.files = OrderedDict()
@@ -117,17 +121,12 @@ class LH5Store:
             mode = self.default_mode
 
         if mode == "r":
-            lh5_file = utils.expand_path(lh5_file, base_path=self.base_path)
             file_kwargs["locking"] = self.locking
 
-        if lh5_file in self.files:
-            self.files.move_to_end(lh5_file)
-            return self.files[lh5_file]
-
-        if self.base_path != "":
-            full_path = Path(self.base_path) / lh5_file
-        else:
-            full_path = Path(lh5_file)
+        full_path = self.base_path.joinpath(lh5_file)
+        if full_path in self.files:
+            self.files.move_to_end(full_path)
+            return self.files[full_path]
 
         file_exists = full_path.exists()
         if mode != "r":
@@ -324,10 +323,10 @@ class LH5Store:
 
         Return ``None`` if it is a :class:`.Scalar` or a :class:`.Struct`.
         """
-        return utils.read_n_rows(name, self.gimme_file(lh5_file, "r"))
+        return utils.read_n_rows(name, self.gimme_file(lh5_file))
 
     def read_size_in_bytes(self, name: str, lh5_file: str | Path | h5py.File) -> int:
         """Look up the size (in bytes) of the object in memory. Will recursively
         crawl through all objects in a Struct or Table.
         """
-        return utils.read_size_in_bytes(name, self.gimme_file(lh5_file, "r"))
+        return utils.read_size_in_bytes(name, self.gimme_file(lh5_file))

--- a/src/lh5/io/store.py
+++ b/src/lh5/io/store.py
@@ -32,9 +32,9 @@ class LH5Store:
     Examples
     --------
     >>> from lh5 import LH5Store
-    >>> store = LH5Store()
-    >>> obj = store.read("/geds/waveform", "file.lh5")
-    >>> type(obj)
+    >>> with LH5Store() as store:
+    >>>     obj = store.read("/geds/waveform", "file.lh5")
+    >>>     type(obj)
     lgdo.waveformtable.WaveformTable
     """
 
@@ -159,7 +159,7 @@ class LH5Store:
 
         if self.keep_open:
             if isinstance(self.keep_open, int) and len(self.files) >= self.keep_open:
-                self.files.popitem(last=False)
+                self.files.popitem(last=False)[1].close()
             self.files[lh5_file] = h5f
 
         return h5f
@@ -295,6 +295,29 @@ class LH5Store:
             write_start=write_start,
             **h5py_kwargs,
         )
+
+    def close(self, lh5_file: str | None = None) -> None:
+        """Close a file in the store and remove from cache.
+
+        If ``lh5_file`` is ``None``, close all files.
+        """
+
+        if lh5_file is None:
+            for h5f in self.files.values():
+                h5f.close()
+            self.files.clear()
+        else:
+            lh5_file = str(Path(lh5_file))
+            if lh5_file in self.files:
+                self.files[lh5_file].close()
+                del self.files[lh5_file]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+        return False
 
     def read_n_rows(self, name: str, lh5_file: str | Path | h5py.File) -> int | None:
         """Look up the number of rows in an Array-like object called `name` in `lh5_file`.

--- a/src/lh5/io/store.py
+++ b/src/lh5/io/store.py
@@ -253,8 +253,8 @@ class LH5Store:
         --------
         .core.write
         """
-        if wo_mode is None and self.default_mode in ["r", "read"]:
-            wo_mode = "a"
+        if wo_mode is None:
+            wo_mode = "a" if self.default_mode in ("r", "read") else self.default_mode
         if wo_mode == "write_safe":
             wo_mode = "w"
         if wo_mode == "append":

--- a/src/lh5/io/store.py
+++ b/src/lh5/io/store.py
@@ -157,7 +157,7 @@ class LH5Store:
             raise LH5DecodeError(oe, full_path) from oe
 
         if self.keep_open:
-            if isinstance(self.keep_open, int) and len(self.files) >= self.keep_open:
+            if self.keep_open is not True and len(self.files) >= self.keep_open:
                 self.files.popitem(last=False)[1].close()
             self.files[lh5_file] = h5f
 

--- a/src/lh5/io/store.py
+++ b/src/lh5/io/store.py
@@ -30,6 +30,11 @@ class LH5Store:
     Class to represent a store of LEGEND HDF5 files. The two main methods
     implemented by the class are :meth:`read` and :meth:`write`.
 
+    ..important::
+        ``h5py`` file objects are not closed until all references are deleted.
+        It is strongly recommended to use the ``LH5Store`` as a context manager
+        to ensure that files are closed, and to not directly access ``h5py`` objects!
+
     Examples
     --------
     >>> from lh5 import LH5Store

--- a/src/lh5/io/store.py
+++ b/src/lh5/io/store.py
@@ -75,23 +75,7 @@ class LH5Store:
         self.keep_open = keep_open
         self.locking = locking
         self.files = OrderedDict()
-
-        if default_mode == "read":
-            default_mode = "r"
-        if default_mode == "write_safe":
-            default_mode = "w"
-        if default_mode == "append":
-            default_mode = "a"
-        if default_mode == "overwrite":
-            default_mode = "o"
-        if default_mode == "overwrite_file":
-            default_mode = "of"
-        if default_mode == "append_column":
-            default_mode = "ac"
-        if default_mode not in ["r", "w", "a", "o", "of", "ac"]:
-            msg = f"unknown wo_mode '{default_mode}'"
-            raise ValueError(msg)
-        self.default_mode = default_mode
+        self.default_mode = utils.normalize_womode(default_mode)
 
     def gimme_file(
         self,
@@ -123,7 +107,15 @@ class LH5Store:
         lh5_file = str(Path(lh5_file))
 
         if mode is None:
-            mode = self.default_mode
+            if self.default_mode == "r":
+                mode = "r"
+            elif (
+                self.default_mode == "of"
+                and str(self.base_path.joinpath(lh5_file)) not in self.files
+            ):
+                mode = "w"
+            else:
+                mode = "a"
 
         if mode == "r":
             file_kwargs["locking"] = self.locking
@@ -149,13 +141,14 @@ class LH5Store:
         if mode != "r" and file_exists:
             log.debug(f"opening existing file {full_path} in mode '{mode}'")
 
-        if mode == "w":
+        if page_buffer > 0 and (not full_path.is_file() or mode == "w"):
             file_kwargs.update(
                 {
                     "fs_strategy": "page",
                     "fs_page_size": page_buffer,
                 }
             )
+
         try:
             h5f = h5py.File(full_path, mode, **file_kwargs)
         except (OSError, FileExistsError) as oe:
@@ -258,22 +251,15 @@ class LH5Store:
         --------
         .core.write
         """
+        wo_mode = utils.normalize_womode(wo_mode)
         if wo_mode is None:
-            wo_mode = "a" if self.default_mode in ("r", "read") else self.default_mode
-        if wo_mode == "write_safe":
-            wo_mode = "w"
-        if wo_mode == "append":
-            wo_mode = "a"
-        if wo_mode == "overwrite":
-            wo_mode = "o"
-        if wo_mode == "overwrite_file":
-            wo_mode = "of"
+            wo_mode = self.default_mode
+            if wo_mode == "r" or (
+                wo_mode == "of" and str(self.base_path.joinpath(lh5_file)) in self.files
+            ):
+                wo_mode = "a"
+        if wo_mode == "of":
             write_start = 0
-        if wo_mode == "append_column":
-            wo_mode = "ac"
-        if wo_mode not in ["w", "a", "o", "of", "ac"]:
-            msg = f"unknown wo_mode '{wo_mode}'"
-            raise ValueError(msg)
 
         # "mode" is for the h5df.File and wo_mode is for this function
         # In hdf5, 'a' is really "modify" -- in addition to appending, you can

--- a/src/lh5/io/store.py
+++ b/src/lh5/io/store.py
@@ -91,7 +91,7 @@ class LH5Store:
     def gimme_file(
         self,
         lh5_file: str | Path | h5py.File,
-        mode: str = None,
+        mode: str | None = None,
         page_buffer: int = 0,
         **file_kwargs,
     ) -> h5py.File:
@@ -242,7 +242,7 @@ class LH5Store:
         group: str | h5py.Group = "/",
         start_row: int = 0,
         n_rows: int | None = None,
-        wo_mode: str = None,
+        wo_mode: str | None = None,
         write_start: int = 0,
         page_buffer: int = 0,
         **h5py_kwargs,

--- a/src/lh5/io/store.py
+++ b/src/lh5/io/store.py
@@ -308,27 +308,15 @@ class LH5Store:
         --------
         .core.write
         """
+        wo_mode = utils.normalize_womode(wo_mode)
         if wo_mode is None:
             wo_mode = self.default_mode
-            if wo_mode in ("r", "read") or (
-                wo_mode in ("of", "overwrite_file")
-                and str(self.base_path.joinpath(lh5_file)) in self.files
+            if wo_mode == "r" or (
+                wo_mode == "of" and str(self.base_path.joinpath(lh5_file)) in self.files
             ):
                 wo_mode = "a"
-        if wo_mode == "write_safe":
-            wo_mode = "w"
-        if wo_mode == "append":
-            wo_mode = "a"
-        if wo_mode == "overwrite":
-            wo_mode = "o"
-        if wo_mode == "overwrite_file":
-            wo_mode = "of"
+        if wo_mode == "of":
             write_start = 0
-        if wo_mode == "append_column":
-            wo_mode = "ac"
-        if wo_mode not in ["w", "a", "o", "of", "ac"]:
-            msg = f"unknown wo_mode '{wo_mode}'"
-            raise ValueError(msg)
 
         # "mode" is for the h5df.File and wo_mode is for this function
         # In hdf5, 'a' is really "modify" -- in addition to appending, you can

--- a/src/lh5/io/store.py
+++ b/src/lh5/io/store.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 from collections.abc import Mapping, Sequence
 from inspect import signature
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import h5py
 from lgdo import types
@@ -123,7 +123,15 @@ class LH5Store:
         lh5_file = str(Path(lh5_file))
 
         if mode is None:
-            mode = self.default_mode
+            if self.default_mode == "r":
+                mode = "r"
+            elif (
+                self.default_mode in ("of", "overwrite_file")
+                and str(self.base_path.joinpath(lh5_file)) not in self.files
+            ):
+                mode = "w"
+            else:
+                mode = "a"
 
         if mode == "r":
             file_kwargs["locking"] = self.locking
@@ -259,7 +267,12 @@ class LH5Store:
         .core.write
         """
         if wo_mode is None:
-            wo_mode = "a" if self.default_mode in ("r", "read") else self.default_mode
+            wo_mode = self.default_mode
+            if wo_mode in ("r", "read") or (
+                wo_mode in ("of", "overwrite_file")
+                and str(self.base_path.joinpath(lh5_file)) in self.files
+            ):
+                wo_mode = "a"
         if wo_mode == "write_safe":
             wo_mode = "w"
         if wo_mode == "append":
@@ -292,6 +305,80 @@ class LH5Store:
             self.gimme_file(
                 lh5_file, mode=mode, page_buffer=page_buffer, **file_kwargs
             ),
+            group=group,
+            start_row=start_row,
+            n_rows=n_rows,
+            wo_mode=wo_mode,
+            write_start=write_start,
+            **h5py_kwargs,
+        )
+
+    def write_view(
+        self,
+        target: str | h5py.Group | h5py.Dataset,
+        entries: ArrayLike,
+        name: str,
+        lh5_file: str | Path | h5py.File,
+        link_type: Literal[None, "hard", "soft", "external"] = None,
+        external_file: str | Path | None = None,
+        group: str | h5py.Group = "/",
+        start_row: int = 0,
+        n_rows: int | None = None,
+        wo_mode: str | None = None,
+        write_start: int = 0,
+        page_buffer: int = 0,
+        **h5py_kwargs,
+    ) -> None:
+        """Write an LGDO into an LH5 file.
+
+        See Also
+        --------
+        .core.write
+        """
+        if wo_mode is None:
+            wo_mode = self.default_mode
+            if wo_mode in ("r", "read") or (
+                wo_mode in ("of", "overwrite_file")
+                and str(self.base_path.joinpath(lh5_file)) in self.files
+            ):
+                wo_mode = "a"
+        if wo_mode == "write_safe":
+            wo_mode = "w"
+        if wo_mode == "append":
+            wo_mode = "a"
+        if wo_mode == "overwrite":
+            wo_mode = "o"
+        if wo_mode == "overwrite_file":
+            wo_mode = "of"
+            write_start = 0
+        if wo_mode == "append_column":
+            wo_mode = "ac"
+        if wo_mode not in ["w", "a", "o", "of", "ac"]:
+            msg = f"unknown wo_mode '{wo_mode}'"
+            raise ValueError(msg)
+
+        # "mode" is for the h5df.File and wo_mode is for this function
+        # In hdf5, 'a' is really "modify" -- in addition to appending, you can
+        # change any object in the file. So we use file:append for
+        # write_object:overwrite.
+        mode = "w" if wo_mode == "of" else "a"
+
+        file_kwargs = {
+            k: h5py_kwargs[k]
+            for k in h5py_kwargs & signature(h5py.File).parameters.keys()
+        }
+
+        lh5_file = self.gimme_file(
+            lh5_file, mode=mode, page_buffer=page_buffer, **file_kwargs
+        )
+
+        return _serializers._h5_write_view(
+            target,
+            entries,
+            name,
+            lh5_file,
+            link_type=link_type,
+            external_file=external_file,
             group=group,
             start_row=start_row,
             n_rows=n_rows,

--- a/src/lh5/io/tools.py
+++ b/src/lh5/io/tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import fnmatch
 import logging
+from contextlib import ExitStack
 from copy import copy
 from pathlib import Path
 
@@ -38,41 +39,44 @@ def ls(
         + ("" if lh5_group == "" else f" (and group {lh5_group})")
     )
 
-    lh5_st = LH5Store()
     # To use recursively, make lh5_file a h5group instead of a string
-    if isinstance(lh5_file, (str, Path)):
-        lh5_file = lh5_st.gimme_file(str(Path(lh5_file)), "r")
-        if lh5_group.startswith("/"):
-            lh5_group = lh5_group[1:]
+    with ExitStack() as stack:
+        if isinstance(lh5_file, (str, Path)):
+            lh5_st = stack.enter_context(LH5Store(keep_open=True, default_mode="r"))
+            lh5_file = lh5_st.gimme_file(lh5_file)
+            if lh5_group.startswith("/"):
+                lh5_group = lh5_group[1:]
 
-    if lh5_group == "":
-        lh5_group = "*"
+        if lh5_group == "":
+            lh5_group = "*"
 
-    # get the first group in the group path
-    splitpath = lh5_group.split("/", 1)
-    # filter out objects that don't match lh5_group pattern
-    matchingkeys = fnmatch.filter(lh5_file.keys(), splitpath[0])
+        # get the first group in the group path
+        splitpath = lh5_group.split("/", 1)
+        # filter out objects that don't match lh5_group pattern
+        matchingkeys = fnmatch.filter(lh5_file.keys(), splitpath[0])
 
-    ret = []
-    # if there were no "/" in lh5_group just return the result
-    if len(splitpath) == 1:
-        ret = matchingkeys
+        ret = []
+        # if there were no "/" in lh5_group just return the result
+        if len(splitpath) == 1:
+            ret = matchingkeys
 
-    else:
-        for key in matchingkeys:
-            ret.extend([f"{key}/{path}" for path in ls(lh5_file[key], splitpath[1])])
+        else:
+            for key in matchingkeys:
+                ret.extend(
+                    [f"{key}/{path}" for path in ls(lh5_file[key], splitpath[1])]
+                )
 
-    if recursive:
-        rec_ret = copy(ret)
-        for obj in ret:
-            try:
-                rec_ret += ls(lh5_file, lh5_group=f"{obj}/", recursive=True)
-            except AttributeError:
-                continue
+        if recursive:
+            rec_ret = copy(ret)
+            for obj in ret:
+                try:
+                    rec_ret += ls(lh5_file, lh5_group=f"{obj}/", recursive=True)
+                except AttributeError:
+                    continue
 
-        return rec_ret
+            return rec_ret
 
-    return ret
+        return ret
 
 
 def show(
@@ -117,118 +121,124 @@ def show(
     │   └── values · array_of_equalsized_arrays<1,1>{real}
     └── wf_std · array<1>{real}
     """
-    # check tree depth if we are using it
-    if depth is not None and depth <= 0:
-        return
+    with ExitStack() as stack:
+        # check tree depth if we are using it
+        if depth is not None and depth <= 0:
+            return
 
-    # open file
-    if isinstance(lh5_file, (str, Path)):
-        try:
-            lh5_file = h5py.File(utils.expand_path(Path(lh5_file)), "r", locking=False)
-        except (OSError, FileExistsError) as oe:
-            raise LH5DecodeError(oe, lh5_file) from oe
-
-    # go to group
-    if lh5_group != "/":
-        lh5_file = lh5_file[lh5_group]
-
-    if header:
-        print(f"\033[1m{lh5_group}\033[0m")  # noqa: T201
-
-    # get an iterator over the keys in the group
-    it = iter(lh5_file)
-    key = None
-
-    # make sure there is actually something in this file/group
-    try:
-        key = next(it)  # get first key
-    except StopIteration:
-        print(f"{indent}└──  empty")  # noqa: T201
-        return
-
-    # loop over keys
-    while True:
-        is_link = False
-        link_type = lh5_file.get(key, getlink=True)
-        if isinstance(link_type, (h5py.SoftLink, h5py.ExternalLink)):
-            desc = f"-> {link_type.path}"
-            is_link = True
-
-        else:
-            val = lh5_file[key]
-
-            # we want to print the LGDO datatype
-            dtype = val.attrs.get("datatype", default="no datatype")
-            if dtype == "no datatype" and isinstance(val, h5py.Group):
-                dtype = "HDF5 group"
-
-            _attrs = ""
-            if attrs:
-                attrs_d = dict(val.attrs)
-                attrs_d.pop("datatype", "")
-                _attrs = "── " + str(attrs_d) if attrs_d else ""
-
-            desc = f"· {dtype} {_attrs}"
-
-        # is this the last key?
-        killme = False
-        try:
-            k_new = next(it)  # get next key
-        except StopIteration:
-            char = "└──"
-            killme = True  # we'll have to kill this loop later
-        else:
-            char = "├──"
-
-        print(f"{indent}{char} \033[1m{key}\033[0m {desc}")  # noqa: T201
-
-        if not is_link and detail and isinstance(val, h5py.Dataset):
-            val = lh5_file[key]
-            char = "|       "
-            if killme:
-                char = "        "
-            toprint = f"{indent}{char}"
+        # open file
+        if isinstance(lh5_file, (str, Path)):
             try:
-                toprint += f"\033[3mdtype\033[0m={val.dtype}"
-                toprint += f", \033[3mshape\033[0m={val.shape}"
-                toprint += f", \033[3mnbytes\033[0m={utils.fmtbytes(val.nbytes)}"
-                if (chunkshape := val.chunks) is None:
-                    toprint += ", \033[3mnumchunks\033[0m=contiguous"
-                else:
-                    toprint += f", \033[3mnumchunks\033[0m={val.id.get_num_chunks()}"
-                    toprint += f", \033[3mchunkshape\033[0m={chunkshape}"
-                toprint += ", \033[3mfilters\033[0m="
+                lh5_st = stack.enter_context(LH5Store(keep_open=True, default_mode="r"))
+                lh5_file = lh5_st.gimme_file(lh5_file)
+            except (OSError, FileExistsError) as oe:
+                raise LH5DecodeError(oe, lh5_file) from oe
 
-                numfilters = val.id.get_create_plist().get_nfilters()
-                if numfilters == 0:
-                    toprint += "None"
-                else:
-                    toprint += "("
-                    for i in range(numfilters):
-                        thisfilter = val.id.get_create_plist().get_filter(i)[3].decode()
-                        if "lz4" in thisfilter:
-                            thisfilter = "lz4"
-                        toprint += f"{thisfilter},"
-                    toprint += ")"
+        # go to group
+        if lh5_group != "/":
+            lh5_file = lh5_file[lh5_group]
 
-            except TypeError:
-                toprint += "(scalar)"
+        if header:
+            print(f"\033[1m{lh5_group}\033[0m")  # noqa: T201
 
-            print(toprint)  # noqa: T201
+        # get an iterator over the keys in the group
+        it = iter(lh5_file)
+        key = None
 
-        # if it's a group, call this function recursively
-        if not is_link and isinstance(val, h5py.Group):
-            show(
-                lh5_file[key],
-                indent=indent + ("    " if killme else "│   "),
-                header=False,
-                attrs=attrs,
-                depth=depth - 1 if depth else None,
-                detail=detail,
-            )
+        # make sure there is actually something in this file/group
+        try:
+            key = next(it)  # get first key
+        except StopIteration:
+            print(f"{indent}└──  empty")  # noqa: T201
+            return
 
-        # break or move to next key
-        if killme:
-            break
+        # loop over keys
+        while True:
+            is_link = False
+            link_type = lh5_file.get(key, getlink=True)
+            if isinstance(link_type, (h5py.SoftLink, h5py.ExternalLink)):
+                desc = f"-> {link_type.path}"
+                is_link = True
 
-        key = k_new
+            else:
+                val = lh5_file[key]
+
+                # we want to print the LGDO datatype
+                dtype = val.attrs.get("datatype", default="no datatype")
+                if dtype == "no datatype" and isinstance(val, h5py.Group):
+                    dtype = "HDF5 group"
+
+                _attrs = ""
+                if attrs:
+                    attrs_d = dict(val.attrs)
+                    attrs_d.pop("datatype", "")
+                    _attrs = "── " + str(attrs_d) if attrs_d else ""
+
+                desc = f"· {dtype} {_attrs}"
+
+            # is this the last key?
+            killme = False
+            try:
+                k_new = next(it)  # get next key
+            except StopIteration:
+                char = "└──"
+                killme = True  # we'll have to kill this loop later
+            else:
+                char = "├──"
+
+            print(f"{indent}{char} \033[1m{key}\033[0m {desc}")  # noqa: T201
+
+            if not is_link and detail and isinstance(val, h5py.Dataset):
+                val = lh5_file[key]
+                char = "|       "
+                if killme:
+                    char = "        "
+                toprint = f"{indent}{char}"
+                try:
+                    toprint += f"\033[3mdtype\033[0m={val.dtype}"
+                    toprint += f", \033[3mshape\033[0m={val.shape}"
+                    toprint += f", \033[3mnbytes\033[0m={utils.fmtbytes(val.nbytes)}"
+                    if (chunkshape := val.chunks) is None:
+                        toprint += ", \033[3mnumchunks\033[0m=contiguous"
+                    else:
+                        toprint += (
+                            f", \033[3mnumchunks\033[0m={val.id.get_num_chunks()}"
+                        )
+                        toprint += f", \033[3mchunkshape\033[0m={chunkshape}"
+                    toprint += ", \033[3mfilters\033[0m="
+
+                    numfilters = val.id.get_create_plist().get_nfilters()
+                    if numfilters == 0:
+                        toprint += "None"
+                    else:
+                        toprint += "("
+                        for i in range(numfilters):
+                            thisfilter = (
+                                val.id.get_create_plist().get_filter(i)[3].decode()
+                            )
+                            if "lz4" in thisfilter:
+                                thisfilter = "lz4"
+                            toprint += f"{thisfilter},"
+                        toprint += ")"
+
+                except TypeError:
+                    toprint += "(scalar)"
+
+                print(toprint)  # noqa: T201
+
+            # if it's a group, call this function recursively
+            if not is_link and isinstance(val, h5py.Group):
+                show(
+                    lh5_file[key],
+                    indent=indent + ("    " if killme else "│   "),
+                    header=False,
+                    attrs=attrs,
+                    depth=depth - 1 if depth else None,
+                    detail=detail,
+                )
+
+            # break or move to next key
+            if killme:
+                break
+
+            key = k_new

--- a/src/lh5/io/utils.py
+++ b/src/lh5/io/utils.py
@@ -6,37 +6,16 @@ import glob
 import logging
 import os
 import string
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
 import h5py
-from lgdo import types
 
 from . import _serializers
 from .exceptions import LH5DecodeError
 
 log = logging.getLogger(__name__)
-
-
-def get_buffer(
-    name: str,
-    lh5_file: str | Path | h5py.File | Sequence[str | Path | h5py.File],
-    size: int | None = None,
-    field_mask: Mapping[str, bool] | Sequence[str] | None = None,
-) -> types.LGDO:
-    """Returns an LGDO appropriate for use as a pre-allocated buffer.
-
-    Sets size to `size` if object has a size.
-    """
-    obj, _n_rows = _serializers._h5_read_lgdo(
-        lh5_file[name], n_rows=0, field_mask=field_mask
-    )
-
-    if hasattr(obj, "resize") and size is not None:
-        obj.resize(new_size=size)
-
-    return obj
 
 
 def read_n_rows(name: str, h5f: str | Path | h5py.File) -> int | None:

--- a/src/lh5/io/utils.py
+++ b/src/lh5/io/utils.py
@@ -225,3 +225,20 @@ def fmtbytes(num, suffix="B"):
             return f"{num:3.1f} {unit}{suffix}"
         num /= 1024.0
     return f"{num:.1f} Y{suffix}"
+
+
+def normalize_womode(wo_mode: str) -> str:
+    """Normalize wo_mode to single-character values and raises exception if
+    this cannot be done."""
+    mode = {
+        "read": "r",
+        "write_safe": "w",
+        "append": "a",
+        "overwrite": "o",
+        "overwrite_file": "of",
+        "append_column": "ac",
+    }.get(wo_mode, wo_mode)
+    if mode not in ("r", "w", "a", "o", "of", "ac", None):
+        msg = f"Invalid wo_mode: {wo_mode}."
+        raise ValueError(msg)
+    return mode

--- a/src/lh5/io/utils.py
+++ b/src/lh5/io/utils.py
@@ -44,38 +44,52 @@ def read_n_rows(name: str, h5f: str | Path | h5py.File) -> int | None:
 
     Return ``None`` if `name` is a :class:`.Scalar` or a :class:`.Struct`.
     """
-    if not isinstance(h5f, h5py.File):
-        try:
-            h5f = h5py.File(h5f, "r", locking=False)
-        except (OSError, FileExistsError) as oe:
-            raise LH5DecodeError(oe, h5f, None) from oe
-
     try:
-        h5o = h5f[name].id
-    except KeyError as e:
-        msg = "not found"
-        raise LH5DecodeError(msg, h5f, name) from e
+        i_opened_file = False
+        if not isinstance(h5f, h5py.File):
+            try:
+                h5f = h5py.File(h5f, "r", locking=False)
+                i_opened_file = True
+            except (OSError, FileExistsError) as oe:
+                raise LH5DecodeError(oe, h5f) from oe
 
-    return _serializers.read.utils.read_n_rows(h5o, h5f.name, name)
+        try:
+            h5o = h5f[name].id
+        except KeyError as e:
+            msg = "not found"
+            raise LH5DecodeError(msg, h5f, name) from e
+
+        return _serializers.read.utils.read_n_rows(h5o, h5f.name, name)
+
+    finally:
+        if i_opened_file:
+            h5f.close()
 
 
 def read_size_in_bytes(name: str, h5f: str | Path | h5py.File) -> int | None:
     """Look up the size (in bytes) of an LGDO object in memory. Will crawl
     recursively through members of a Struct or Table.
     """
-    if not isinstance(h5f, h5py.File):
-        try:
-            h5f = h5py.File(h5f, "r", locking=False)
-        except (OSError, FileExistsError) as oe:
-            raise LH5DecodeError(oe, h5f) from oe
-
     try:
-        h5o = h5f[name].id
-    except KeyError as e:
-        msg = "not found"
-        raise LH5DecodeError(msg, h5f, name) from e
+        i_opened_file = False
+        if not isinstance(h5f, h5py.File):
+            try:
+                h5f = h5py.File(h5f, "r", locking=False)
+                i_opened_file = True
+            except (OSError, FileExistsError) as oe:
+                raise LH5DecodeError(oe, h5f) from oe
 
-    return _serializers.read.utils.read_size_in_bytes(h5o, h5f.name, name)
+        try:
+            h5o = h5f[name].id
+        except KeyError as e:
+            msg = "not found"
+            raise LH5DecodeError(msg, h5f, name) from e
+
+        return _serializers.read.utils.read_size_in_bytes(h5o, h5f.name, name)
+
+    finally:
+        if i_opened_file:
+            h5f.close()
 
 
 def get_h5_group(

--- a/tests/lh5/test_core.py
+++ b/tests/lh5/test_core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import lgdo
 import numpy as np
 import pytest
+from lgdo import types
 
 import lh5
 
@@ -104,3 +105,26 @@ def test_read_hdf5plugin_compression(lgnd_file_new_format):
     lh5_obj = lh5.read("/raw/B00000D/baseline", lgnd_file_new_format)
     assert isinstance(lh5_obj, lgdo.Array)
     assert lh5_obj.nda[0] == 14620
+
+
+def test_views(tmptestdir):
+    # Note: this test just tests core.write_view, not the inner workings.
+    # test_lh5_store has more extensive tests
+    test_file = f"{tmptestdir}/test_view.lh5"
+    array = lgdo.Array(np.arange(100, dtype=np.int64))
+    entries_1d = np.array([1, 2, 3, 5, 8, 13, 21, 34, 55, 89], dtype=np.int64)
+    expected_1d = np.copy(entries_1d)
+
+    lh5.write(array, "array", test_file, group="/data")
+    lh5.write_view(
+        "/data/array",
+        entries_1d,
+        "hard_1d",
+        test_file,
+        link_type="hard",
+        group="/views",
+    )
+
+    ar_h1d = lh5.read("/views/hard_1d", test_file)
+    assert isinstance(ar_h1d, types.Array)
+    assert np.all(ar_h1d.nda == expected_1d)

--- a/tests/lh5/test_lh5_iterator.py
+++ b/tests/lh5/test_lh5_iterator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pickle
 import shutil
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from copy import deepcopy
 
 import awkward as ak
@@ -819,11 +820,25 @@ def test_map(more_lgnd_files):
     sum_map = lh5_it.map(sumE, aggregate=np.add, init=-10.0)
     assert sum_exp - 10.0 == sum_map
 
-    # test multiprocessing; note this only works as done here if
+    # test default multi-processing; note this only works as done here if
     # buffer_len evenly divides iterator length for each file!
     map_mp = lh5_it.map(return_tb, processes=2)
 
-    assert all(tb == tb_mp for tb, tb_mp in zip(lh5_it, map_mp, strict=False))
+    assert all(tb == tb_mp for tb, tb_mp in zip(lh5_it, map_mp, strict=True))
+
+    # test multithreading
+    with ThreadPoolExecutor(2) as thread_pool:
+        with MapProgress(2, thread_pool) as prog:
+            map_mt = lh5_it.map(return_tb, processes=2, executor=thread_pool, progress_queue=prog.queue)
+            assert all(tb == tb_mt for tb, tb_mt in zip(lh5_it, map_mt, strict=True))
+
+    # test multiprocessing
+    with ProcessPoolExecutor(2) as process_pool:
+        with MapProgress(2, process_pool) as prog:
+            map_mp = lh5_it.map(return_tb, processes=2, executor=process_pool, progress_queue=prog.queue)
+            assert all(tb == tb_mp for tb, tb_mp in zip(lh5_it, map_mp, strict=True))
+
+    # TODO: once numpy figures out InterpreterPoolProcessor, add a test for intepreter pool
 
 
 def query_lgdo(tb, _):

--- a/tests/lh5/test_lh5_iterator.py
+++ b/tests/lh5/test_lh5_iterator.py
@@ -827,22 +827,20 @@ def test_map(more_lgnd_files):
     assert all(tb == tb_mp for tb, tb_mp in zip(lh5_it, map_mp, strict=True))
 
     # test multithreading
-    with ThreadPoolExecutor(2) as thread_pool:
-        with MapProgress(2, thread_pool) as prog:
-            map_mt = lh5_it.map(
-                return_tb, processes=2, executor=thread_pool, progress_queue=prog.queue
-            )
-            assert all(tb == tb_mt for tb, tb_mt in zip(lh5_it, map_mt, strict=True))
+    with ThreadPoolExecutor(2) as thread_pool, MapProgress(2, thread_pool) as prog:
+        map_mt = lh5_it.map(
+            return_tb, processes=2, executor=thread_pool, progress_queue=prog.queue
+        )
+        assert all(tb == tb_mt for tb, tb_mt in zip(lh5_it, map_mt, strict=True))
 
     # test multiprocessing
-    with ProcessPoolExecutor(2) as process_pool:
-        with MapProgress(2, process_pool) as prog:
-            map_mp = lh5_it.map(
-                return_tb, processes=2, executor=process_pool, progress_queue=prog.queue
-            )
-            assert all(tb == tb_mp for tb, tb_mp in zip(lh5_it, map_mp, strict=True))
+    with ProcessPoolExecutor(2) as process_pool, MapProgress(2, process_pool) as prog:
+        map_mp = lh5_it.map(
+            return_tb, processes=2, executor=process_pool, progress_queue=prog.queue
+        )
+        assert all(tb == tb_mp for tb, tb_mp in zip(lh5_it, map_mp, strict=True))
 
-    # TODO: once numpy figures out InterpreterPoolProcessor, add a test for intepreter pool
+    # TODO: once numpy figures out InterpreterPoolProcessor, add a test for interpreter pool
 
 
 def query_lgdo(tb, _):

--- a/tests/lh5/test_lh5_iterator.py
+++ b/tests/lh5/test_lh5_iterator.py
@@ -829,13 +829,17 @@ def test_map(more_lgnd_files):
     # test multithreading
     with ThreadPoolExecutor(2) as thread_pool:
         with MapProgress(2, thread_pool) as prog:
-            map_mt = lh5_it.map(return_tb, processes=2, executor=thread_pool, progress_queue=prog.queue)
+            map_mt = lh5_it.map(
+                return_tb, processes=2, executor=thread_pool, progress_queue=prog.queue
+            )
             assert all(tb == tb_mt for tb, tb_mt in zip(lh5_it, map_mt, strict=True))
 
     # test multiprocessing
     with ProcessPoolExecutor(2) as process_pool:
         with MapProgress(2, process_pool) as prog:
-            map_mp = lh5_it.map(return_tb, processes=2, executor=process_pool, progress_queue=prog.queue)
+            map_mp = lh5_it.map(
+                return_tb, processes=2, executor=process_pool, progress_queue=prog.queue
+            )
             assert all(tb == tb_mp for tb, tb_mp in zip(lh5_it, map_mp, strict=True))
 
     # TODO: once numpy figures out InterpreterPoolProcessor, add a test for intepreter pool

--- a/tests/lh5/test_lh5_store.py
+++ b/tests/lh5/test_lh5_store.py
@@ -26,6 +26,24 @@ def test_gimme_file(lgnd_file):
     with pytest.raises(FileNotFoundError):
         store.gimme_file("non-existent-file")
 
+def test_close_file(lgnd_file):
+    store = lh5.LH5Store(keep_open=True)
+
+    f = store.gimme_file(lgnd_file)
+    assert isinstance(f, h5py.File)
+    assert store.files[lgnd_file] == f
+    store.close(lgnd_file)
+    assert not f.id.valid
+    assert lgnd_file not in store.files
+
+    f = store.gimme_file(lgnd_file)
+    store.close()
+    assert not f.id.valid
+    assert lgnd_file not in store.files
+
+    with lh5.LH5Store(keep_open=True) as st:
+        f = st.gimme_file(lgnd_file)
+    assert not f.id.valid
 
 def test_gimme_group(lgnd_file, tmptestdir):
     f = h5py.File(lgnd_file)

--- a/tests/lh5/test_lh5_store.py
+++ b/tests/lh5/test_lh5_store.py
@@ -862,3 +862,431 @@ def test_read_histogram_multiple(lgnd_test_data):
     file = lgnd_test_data.get_path("lh5/lgdo-histograms.lh5")
     with pytest.raises(lh5.io.exceptions.LH5DecodeError):
         lh5.read("test_histogram_range", [file, file])
+
+
+def test_views(tmptestdir):
+    test_file = f"{tmptestdir}/test_view.lh5"
+    external_file = f"{tmptestdir}/test_view_external.lh5"
+
+    array = lgdo.Array(np.arange(100, dtype=np.int64))
+    array2 = lgdo.Array(-np.arange(100, dtype=np.int64))
+
+    entries_1d = np.array([1, 2, 3, 5, 8, 13, 21, 34, 55, 89], dtype=np.int64)
+    entries_2d = np.array([[0, 2], [10, 13], [98, 100]], dtype=np.int64)
+    expected_1d = np.copy(entries_1d)
+    expected_2d = np.concatenate(
+        [np.arange(a, b, dtype=np.int64) for a, b in entries_2d]
+    )
+
+    with lh5.LH5Store(keep_open=True, default_mode="of") as store:
+        store.write(array, "array", test_file, group="/data")
+        store.write(array2, "array2", test_file, group="/data")
+
+        store.write_view(
+            "/data/array",
+            entries_1d,
+            "hard_1d",
+            test_file,
+            link_type="hard",
+            group="/views",
+        )
+
+        store.write_view(
+            "/data/array",
+            entries_1d,
+            "soft_1d",
+            test_file,
+            link_type="soft",
+            group="/views",
+        )
+
+        store.write_view(
+            "/data/array",
+            entries_1d,
+            "external_1d",
+            external_file,
+            link_type="external",
+            external_file=test_file,
+            group="/views",
+        )
+
+        store.write_view(
+            "/data/array",
+            entries_2d,
+            "hard_2d",
+            test_file,
+            link_type="hard",
+            group="/views",
+        )
+
+        store.write_view(
+            "/data/array",
+            entries_2d,
+            "soft_2d",
+            test_file,
+            link_type="soft",
+            group="/views",
+        )
+
+        store.write_view(
+            "/data/array",
+            entries_2d,
+            "external_2d",
+            external_file,
+            link_type="external",
+            external_file=test_file,
+            group="/views",
+        )
+
+    with lh5.LH5Store(keep_open=True, default_mode="r") as store:
+        lh5_file = store.gimme_file(test_file)
+        ext_file = store.gimme_file(external_file)
+
+        ar_h1d = store.read("/views/hard_1d", test_file)
+        assert isinstance(ar_h1d, types.Array)
+        assert np.all(ar_h1d.nda == expected_1d)
+        assert isinstance(
+            lh5_file["views/hard_1d"].get("data", getlink=True), h5py.HardLink
+        )
+
+        ar_s1d = store.read("/views/soft_1d", test_file)
+        assert isinstance(ar_s1d, types.Array)
+        assert np.all(ar_s1d.nda == expected_1d)
+        assert isinstance(
+            lh5_file["views/soft_1d"].get("data", getlink=True), h5py.SoftLink
+        )
+
+        ar_e1d = store.read("/views/external_1d", external_file)
+        assert isinstance(ar_e1d, types.Array)
+        assert np.all(ar_e1d.nda == expected_1d)
+        assert isinstance(
+            ext_file["views/external_1d"].get("data", getlink=True), h5py.ExternalLink
+        )
+
+        ar_h2d = store.read("/views/hard_2d", test_file)
+        assert isinstance(ar_h2d, types.Array)
+        assert np.all(ar_h2d.nda == expected_2d)
+        assert isinstance(
+            lh5_file["views/hard_2d"].get("data", getlink=True), h5py.HardLink
+        )
+
+        ar_s2d = store.read("/views/soft_2d", test_file)
+        assert isinstance(ar_s2d, types.Array)
+        assert np.all(ar_s2d.nda == expected_2d)
+        assert isinstance(
+            lh5_file["views/soft_2d"].get("data", getlink=True), h5py.SoftLink
+        )
+
+        ar_e2d = store.read("/views/external_2d", external_file)
+        assert isinstance(ar_e2d, types.Array)
+        assert np.all(ar_e2d.nda == expected_2d)
+        assert isinstance(
+            ext_file["views/external_2d"].get("data", getlink=True), h5py.ExternalLink
+        )
+
+        del lh5_file
+        del ext_file
+
+    # we shouldn't be able to write_safe to an existing view...
+    with (
+        lh5.LH5Store(keep_open=True, default_mode="w") as store,
+        pytest.raises(lh5.io.exceptions.LH5EncodeError),
+    ):
+        store.write_view(
+            "/data/array",
+            entries_1d,
+            "hard_1d",
+            test_file,
+            link_type="hard",
+            group="/views",
+        )
+
+    # append
+    entries_app = np.array([91, 92, 93, 94, 95], dtype=np.int64)
+    expected_app = np.concatenate([expected_1d, entries_app])
+    with lh5.LH5Store(keep_open=True, default_mode="a") as store:
+        store.write_view(
+            "/data/array",
+            entries_app,
+            "hard_1d",
+            test_file,
+            link_type="hard",
+            group="/views",
+        )
+
+        store.write_view(
+            "/data/array",
+            entries_app,
+            "soft_1d",
+            test_file,
+            link_type="soft",
+            group="/views",
+        )
+
+        store.write_view(
+            "/data/array",
+            entries_app,
+            "external_1d",
+            external_file,
+            link_type="external",
+            external_file=test_file,
+            group="/views",
+        )
+
+        # error if we use a different array
+        with pytest.raises(lh5.io.exceptions.LH5EncodeError):
+            store.write_view(
+                "/data/array2",
+                entries_app,
+                "hard_1d",
+                test_file,
+                link_type="hard",
+                group="/views",
+            )
+
+        with pytest.raises(lh5.io.exceptions.LH5EncodeError):
+            store.write_view(
+                "/data/array2",
+                entries_app,
+                "soft_1d",
+                test_file,
+                link_type="soft",
+                group="/views",
+            )
+
+        with pytest.raises(lh5.io.exceptions.LH5EncodeError):
+            store.write_view(
+                "/data/array2",
+                entries_app,
+                "external_1d",
+                external_file,
+                link_type="external",
+                external_file=test_file,
+                group="/views",
+            )
+
+    with lh5.LH5Store(keep_open=True, default_mode="r") as store:
+        lh5_file = store.gimme_file(test_file)
+        ext_file = store.gimme_file(external_file)
+
+        ar_h1d = store.read("/views/hard_1d", test_file)
+        assert isinstance(ar_h1d, types.Array)
+        assert np.all(ar_h1d.nda == expected_app)
+        assert isinstance(
+            lh5_file["views/hard_1d"].get("data", getlink=True), h5py.HardLink
+        )
+
+        ar_s1d = store.read("/views/soft_1d", test_file)
+        assert isinstance(ar_s1d, types.Array)
+        assert np.all(ar_s1d.nda == expected_app)
+        assert isinstance(
+            lh5_file["views/soft_1d"].get("data", getlink=True), h5py.SoftLink
+        )
+
+        ar_e1d = store.read("/views/external_1d", external_file)
+        assert isinstance(ar_e1d, types.Array)
+        assert np.all(ar_e1d.nda == expected_app)
+        assert isinstance(
+            ext_file["views/external_1d"].get("data", getlink=True), h5py.ExternalLink
+        )
+
+        del lh5_file
+        del ext_file
+
+    # overwrite
+    with lh5.LH5Store(keep_open=True, default_mode="o") as store:
+        store.write_view(
+            "/data/array2",
+            entries_1d,
+            "hard_1d",
+            test_file,
+            link_type="hard",
+            group="/views",
+        )
+
+        store.write_view(
+            "/data/array2",
+            entries_1d,
+            "soft_1d",
+            test_file,
+            link_type="soft",
+            group="/views",
+        )
+
+        store.write_view(
+            "/data/array2",
+            entries_1d,
+            "external_1d",
+            external_file,
+            link_type="external",
+            external_file=test_file,
+            group="/views",
+        )
+
+    with lh5.LH5Store(keep_open=True, default_mode="r") as store:
+        ar_h1d = store.read("/views/hard_1d", test_file)
+        assert isinstance(ar_h1d, types.Array)
+        assert np.all(ar_h1d.nda == -expected_1d)
+
+        ar_s1d = store.read("/views/soft_1d", test_file)
+        assert isinstance(ar_s1d, types.Array)
+        assert np.all(ar_s1d.nda == -expected_1d)
+
+        ar_e1d = store.read("/views/external_1d", external_file)
+        assert isinstance(ar_e1d, types.Array)
+        assert np.all(ar_e1d.nda == -expected_1d)
+
+    # Test automatic deduction of link type from inputs
+    with lh5.LH5Store(keep_open=True, default_mode="o") as store:
+        lh5_file = store.gimme_file(test_file)
+        data_array = store.gimme_group("/data/array", lh5_file)
+        data_array2 = store.gimme_group("/data/array2", lh5_file)
+
+        store.write_view(
+            data_array,
+            entries_1d,
+            "hard_1d",
+            test_file,
+            group="/views",
+        )
+
+        store.write_view(
+            "/data/array",
+            entries_1d,
+            "soft_1d",
+            test_file,
+            group="/views",
+        )
+
+        store.write_view(
+            data_array,
+            entries_1d,
+            "external_1d",
+            external_file,
+            external_file=test_file,
+            group="/views",
+        )
+
+        # should error if group doesn't match external file
+        with pytest.raises(lh5.io.exceptions.LH5EncodeError):
+            store.write_view(
+                data_array,
+                entries_1d,
+                "external_1d",
+                external_file,
+                external_file=external_file,
+                group="/views",
+            )
+
+        # should figure out file on its own if it is external
+        store.write_view(
+            data_array2,
+            entries_1d,
+            "external2_1d",
+            external_file,
+            group="/views",
+        )
+
+        del lh5_file
+        del data_array
+        del data_array2
+
+    with lh5.LH5Store(keep_open=True, default_mode="r") as store:
+        ar_h1d = store.read("/views/hard_1d", test_file)
+        assert isinstance(ar_h1d, types.Array)
+        assert np.all(ar_h1d.nda == expected_1d)
+
+        ar_s1d = store.read("/views/soft_1d", test_file)
+        assert isinstance(ar_s1d, types.Array)
+        assert np.all(ar_s1d.nda == expected_1d)
+
+        ar_e1d = store.read("/views/external_1d", external_file)
+        assert isinstance(ar_e1d, types.Array)
+        assert np.all(ar_e1d.nda == expected_1d)
+
+        ar_e1d = store.read("/views/external2_1d", external_file)
+        assert isinstance(ar_e1d, types.Array)
+        assert np.all(ar_e1d.nda == -expected_1d)
+
+    # Test other sorts of errors...
+    with lh5.LH5Store(keep_open=True, default_mode="a") as store:
+        with pytest.raises(TypeError):
+            store.write_view(
+                "/data/array",
+                np.array(entries_1d, dtype="float32"),
+                "hard_1d",
+                test_file,
+                link_type="hard",
+                group="/views",
+            )
+
+        with pytest.raises(lh5.io.exceptions.LH5EncodeError):
+            store.write_view(
+                "/data/array",
+                np.array([5, 4, 3, 2, 1], dtype="int64"),
+                "hard_1d",
+                test_file,
+                link_type="hard",
+                group="/views",
+            )
+
+        with pytest.raises(lh5.io.exceptions.LH5EncodeError):
+            store.write_view(
+                "/data/array",
+                np.arange(12, dtype="int64").reshape((3, 4)),
+                "hard_1d",
+                test_file,
+                link_type="hard",
+                group="/views",
+            )
+
+        with pytest.raises(ValueError):
+            store.write_view(
+                "/data/array",
+                entries_1d,
+                "hard_1d",
+                test_file,
+                link_type="hard",
+                external_file=external_file,
+                group="/views",
+            )
+
+        with pytest.raises(ValueError):
+            store.write_view(
+                "/data/array",
+                entries_1d,
+                "soft_1d",
+                test_file,
+                link_type="soft",
+                external_file=external_file,
+                group="/views",
+            )
+
+        store.write_view(
+            "/data/array3",
+            entries_1d,
+            "soft_missing",
+            test_file,
+            link_type="soft",
+            group="/views",
+        )
+        with pytest.raises(lh5.io.exceptions.LH5DecodeError):
+            store.read("/views/soft_missing", test_file)
+
+    # test with empty entries list
+    with lh5.LH5Store(keep_open=True, default_mode="of") as store:
+        store.write(array, "array", test_file, group="/data")
+
+        store.write_view(
+            "/data/array",
+            np.array([], dtype="int64").reshape((0,)),
+            "hard_1d",
+            test_file,
+            link_type="hard",
+            group="/views",
+        )
+
+    with lh5.LH5Store(keep_open=True, default_mode="r") as store:
+        ar_h1d = store.read("/views/hard_1d", test_file)
+        assert isinstance(ar_h1d, types.Array)
+        assert np.all(ar_h1d.nda == np.array([], dtype="int64"))

--- a/tests/lh5/test_lh5_store.py
+++ b/tests/lh5/test_lh5_store.py
@@ -26,6 +26,7 @@ def test_gimme_file(lgnd_file):
     with pytest.raises(FileNotFoundError):
         store.gimme_file("non-existent-file")
 
+
 def test_close_file(lgnd_file):
     store = lh5.LH5Store(keep_open=True)
 
@@ -44,6 +45,7 @@ def test_close_file(lgnd_file):
     with lh5.LH5Store(keep_open=True) as st:
         f = st.gimme_file(lgnd_file)
     assert not f.id.valid
+
 
 def test_gimme_group(lgnd_file, tmptestdir):
     f = h5py.File(lgnd_file)


### PR DESCRIPTION
Added support for [LH5 Views](https://legend-exp.github.io/legend-data-format-specs/dev/hdf5/#Views)

Implementation:
- Added `write_view` to `core` and `store.LH5Store`. These functions take:
  -  `target` (a group/dataset or path representing another LH5 object) for the View to point at
  - `entries` (a numpy array or arraylike) representing an entry list or slice list
  - `name` (a string) is the name of the view
  - `link_type` ("hard", "soft", "external" or `None`) is the type of link to use; `None` will automatically figure it out from the provided target (if a str path, use soft, if a Group use hard, if the Group points to another file and/or external_file is provided use external)
  - `external_file` (HDF5 file or str) is the file to point to if an external link is used
  - The other standard write arguments. When setting the `wo_mode`, there are cross-checks for if the link is the same as target (unless overwriting), and any amendments are made to the entry list (although there are not checks that amended entries do not break it by being out of order). As much as possible, existing logic was used to handle these
- No new function was needed for reading; `read` will automatically read the link contents and apply the entry list, which will be mostly invisible to the user. Existing logic for reading with entry lists was used to perform the reads. Under the hood, reading a view consists of reading in the entry list, and then calling `_h5_read_lgdo` on the link, using the entrylist.
- The logic for reading, writing, and validating these is implemented in new `_serializers/read/view.py` and `_serializers/write/view.py`
- Tests were added to `test_lh5_store` and `test_core`; most of the tests are in `test_lh5_store`. The tests cover many permutations of `wo_mode`s and `link_type`s

Todo:
- Views are still not handled in `_serializers/read/utils.py`, particularly `read_n_rows` and `read_size_in_bytes`

Plan:
- Use Views to store views of `evt`/`tcm`/etc. event-level tier tables for each channel. This will make it trivial to join channel-level tiers (e.g. `dsp`/`hit`) to event-level tiers. This especially matters for data taken in non-sparse mode (e.g. for tagging pulsers)